### PR TITLE
Update import directives to use gopkg.in/throttled/throttled.v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
-# Throttled [![build status](https://secure.travis-ci.org/throttled/throttled.png)](http://travis-ci.org/throttled/throttled) [![GoDoc](https://godoc.org/github.com/throttled/throttled?status.png)](http://godoc.org/github.com/throttled/throttled)
+# Throttled [![build status](https://secure.travis-ci.org/throttled/throttled.png)](http://travis-ci.org/throttled/throttled) [![GoDoc](https://godoc.org/gopkg.in/throttled/throttled.v1?status.png)](http://godoc.org/gopkg.in/throttled/throttled.v1)
 
 Package throttled implements different throttling strategies for controlling
 access to HTTP handlers.
 
-*As of July 27, 2015, the package is now located under its own GitHub organization, please adjust your imports to `github.com/throttled/throttled`.*
+*As of July 27, 2015, the package is now located under its own GitHub
+ organization and uses gopkg.in for versioning, please adjust your
+ imports to `gopkg.in/throttled/throttled.v1`.*
 
 ## Installation
 
-`go get github.com/throttled/throttled/...`
+`go get gopkg.in/throttled/throttled.v1/...`
 
 ## Interval
 
@@ -75,6 +77,6 @@ Finally, many examples are provided in the /examples sub-folder of the repositor
 
 The [BSD 3-clause license][bsd]. Copyright (c) 2014 Martin Angers and Contributors.
 
-[doc]: http://godoc.org/github.com/throttled/throttled
+[doc]: http://godoc.org/gopkg.in/throttled/throttled.v1
 [blog]: http://0value.com/throttled--guardian-of-the-web-server
 [bsd]: http://opensource.org/licenses/BSD-3-Clause

--- a/doc.go
+++ b/doc.go
@@ -3,7 +3,7 @@
 //
 // Installation
 //
-// go get github.com/throttled/throttled/...
+// go get gopkg.in/throttled/throttled.v1/...
 //
 // Inverval
 //
@@ -62,7 +62,7 @@
 // Documentation
 //
 // The API documentation is available as usual on godoc.org:
-//    http://godoc.org/github.com/throttled/throttled
+//    http://godoc.org/gopkg.in/throttled/throttled.v1
 //
 // There is also a blog post explaining the package's usage on 0value.com:
 //    http://0value.com/throttled--guardian-of-the-web-server
@@ -74,4 +74,4 @@
 // The BSD 3-clause license. Copyright (c) 2014 Martin Angers and Contributors.
 //    http://opensource.org/licenses/BSD-3-Clause
 //
-package throttled // import "github.com/throttled/throttled"
+package throttled // import "gopkg.in/throttled/throttled.v1"

--- a/examples/custom/main.go
+++ b/examples/custom/main.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/throttled/throttled"
+	"gopkg.in/throttled/throttled.v1"
 )
 
 var (

--- a/examples/interval-many/main.go
+++ b/examples/interval-many/main.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/throttled/throttled"
+	"gopkg.in/throttled/throttled.v1"
 )
 
 var (

--- a/examples/interval-vary/main.go
+++ b/examples/interval-vary/main.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/throttled/throttled"
+	"gopkg.in/throttled/throttled.v1"
 )
 
 var (

--- a/examples/interval/main.go
+++ b/examples/interval/main.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/throttled/throttled"
+	"gopkg.in/throttled/throttled.v1"
 )
 
 var (

--- a/examples/memstats/main.go
+++ b/examples/memstats/main.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/throttled/throttled"
+	"gopkg.in/throttled/throttled.v1"
 )
 
 var (

--- a/examples/rate-limit/main.go
+++ b/examples/rate-limit/main.go
@@ -10,8 +10,8 @@ import (
 	"time"
 
 	"github.com/garyburd/redigo/redis"
-	"github.com/throttled/throttled"
-	"github.com/throttled/throttled/store"
+	"gopkg.in/throttled/throttled.v1"
+	"gopkg.in/throttled/throttled.v1/store"
 )
 
 var (

--- a/store/doc.go
+++ b/store/doc.go
@@ -1,2 +1,2 @@
 // Package store offers a memory-based and a Redis-based throttled.Store implementation.
-package store // import "github.com/throttled/throttled/store"
+package store // import "gopkg.in/throttled/throttled.v1/store"

--- a/store/mem.go
+++ b/store/mem.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/golang/groupcache/lru"
-	"github.com/throttled/throttled"
+	"gopkg.in/throttled/throttled.v1"
 )
 
 // memStore implements an in-memory Store.

--- a/store/redis.go
+++ b/store/redis.go
@@ -4,7 +4,7 @@ import (
 	"time"
 
 	"github.com/garyburd/redigo/redis"
-	"github.com/throttled/throttled"
+	"gopkg.in/throttled/throttled.v1"
 )
 
 // redisStore implements a Redis-based store.


### PR DESCRIPTION
This will be tagged as 1.0.0, the first versioned release.