### PR TITLE
Fix parsing of `TIME` in redigostore

### DIFF
--- a/store/redigostore/redigostore.go
+++ b/store/redigostore/redigostore.go
@@ -74,7 +74,7 @@ func (r *RedigoStore) GetWithTime(key string) (int64, time.Time, error) {
 	if _, err := redis.Scan(timeReply, &s, &ms); err != nil {
 		return 0, now, err
 	}
-	now = time.Unix(s, ms*int64(time.Millisecond))
+	now = time.Unix(s, ms*int64(time.Microsecond))
 
 	v, err := redis.Int64(conn.Receive())
 	if err == redis.ErrNil {

--- a/store/redigostore/redigostore.go
+++ b/store/redigostore/redigostore.go
@@ -70,11 +70,11 @@ func (r *RedigoStore) GetWithTime(key string) (int64, time.Time, error) {
 		return 0, now, err
 	}
 
-	var s, ms int64
-	if _, err := redis.Scan(timeReply, &s, &ms); err != nil {
+	var s, us int64
+	if _, err := redis.Scan(timeReply, &s, &us); err != nil {
 		return 0, now, err
 	}
-	now = time.Unix(s, ms*int64(time.Microsecond))
+	now = time.Unix(s, us*int64(time.Microsecond))
 
 	v, err := redis.Int64(conn.Receive())
 	if err == redis.ErrNil {

--- a/store/storetest/storetest.go
+++ b/store/storetest/storetest.go
@@ -31,12 +31,22 @@ func TestGCRAStore(t *testing.T, st throttled.GCRAStore) {
 		t.Errorf("expected SetIfNotExists on an empty key to succeed")
 	}
 
+	before := time.Now()
+
 	if have, now, err := st.GetWithTime("foo"); err != nil {
 		t.Fatal(err)
 	} else if have != want {
 		t.Errorf("expected GetWithTime to return %d but got %d", want, have)
 	} else if now.UnixNano() <= 0 {
 		t.Errorf("expected GetWithTime to return a time representable representable as a positive int64 of nanoseconds since the epoch")
+	} else if now.Before(before) || now.After(time.Now()) {
+		// Note that we make the assumption here that the store is running on
+		// the same machine as this test and thus shares a clock. This can be a
+		// little tricky in the case of Redis, which could be running
+		// elsewhere. The test assumes that it's running either locally on on
+		// Travis (where currently the Redis is available on localhost). If new
+		// test environments are procured, this may need to be revisited.
+		t.Errorf("expected GetWithTime to return a time between the time before the call and the time after the call")
 	}
 
 	// SetIfNotExists on an existing key


### PR DESCRIPTION
I noticed that the current time being returned from this store looked
off, and upon [reading the docs for Redis' TIME][redis-time], it looks
like the second element in the array is actually supposed to be read as
microseconds. This patch changes the current millisecond implementation
to microseconds.

/cc @metcalf Can you sanity check this? Thanks!

[redis-time]: http://redis.io/commands/time