### PR TITLE
Add example demonstrating granular use of RateLimit

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -1,6 +1,7 @@
 package throttled_test
 
 import (
+	"fmt"
 	"log"
 	"net/http"
 
@@ -21,7 +22,9 @@ func ExampleHTTPRateLimiter() {
 		log.Fatal(err)
 	}
 
+	// Maximum burst of 5 which refills at 20 tokens per minute.
 	quota := throttled.RateQuota{throttled.PerMin(20), 5}
+
 	rateLimiter, err := throttled.NewGCRARateLimiter(store, quota)
 	if err != nil {
 		log.Fatal(err)
@@ -33,4 +36,46 @@ func ExampleHTTPRateLimiter() {
 	}
 
 	http.ListenAndServe(":8080", httpRateLimiter.RateLimit(myHandler))
+}
+
+// Demonstrates direct use of GCRARateLimiter's RateLimit function (and the
+// more general RateLimiter interface). This should be used anywhere where
+// granular control over rate limiting is required.
+func ExampleGCRARateLimiter() {
+	store, err := memstore.New(65536)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Maximum burst of 5 which refills at 20 tokens per minute.
+	quota := throttled.RateQuota{throttled.PerMin(20), 5}
+
+	rateLimiter, err := throttled.NewGCRARateLimiter(store, quota)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		// Bucket based on the address of the origin request. This actually
+		// includes a remote port as well and as such, is not actually
+		// particularly useful for rate limiting, but does serve as a simple
+		// demonstration.
+		bucket := r.RemoteAddr
+
+		// add one token to the bucket
+		limited, result, err := rateLimiter.RateLimit(bucket, 1)
+		if err != nil {
+			w.WriteHeader(500)
+			fmt.Fprintf(w, "Internal error: %v.", err.Error())
+		}
+
+		if limited {
+			w.WriteHeader(429)
+			fmt.Fprintf(w, "Rate limit exceeded. Please try again in %v.",
+				result.RetryAfter)
+		} else {
+			fmt.Fprintf(w, "Hello.")
+		}
+	})
+	http.ListenAndServe(":8080", nil)
 }


### PR DESCRIPTION
This adds a second example to the documentation which is similar to the
first, but demonstrates the granular use of the GCRARateLimiter's
RateLimit function. This should hopefully serve as a useful example for
anyone who needs access to an API that offers more fine-grain control.