### PR TITLE
Use non-HTTP example for GCRARateLimiter

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -55,7 +55,7 @@ func ExampleGCRARateLimiter() {
 		log.Fatal(err)
 	}
 
-	// Bucket according to the our number i / 10 (so 1 falls into the bucket 0
+	// Bucket according to the number i / 10 (so 1 falls into the bucket 0
 	// while 11 falls into the bucket 1). This has the effect of allowing a
 	// burst of 5 plus 1 (a single emission interval) on every ten iterations
 	// of the loop. See the output for better clarity here.
@@ -71,32 +71,33 @@ func ExampleGCRARateLimiter() {
 		}
 
 		if limited {
-			fmt.Printf("Bucket %v: FAILED. Rate limit exceeded.\n", bucket)
+			fmt.Printf("Iteration %2v; bucket %v: FAILED. Rate limit exceeded.\n",
+				i, bucket)
 		} else {
-			fmt.Printf("Bucket %v: Operation successful (remaining=%v).\n",
-			  bucket, result.Remaining)
+			fmt.Printf("Iteration %2v; bucket %v: Operation successful (remaining=%v).\n",
+				i, bucket, result.Remaining)
 		}
 	}
 
 	// Output:
-	// Bucket by-order:0: Operation successful (remaining=5).
-	// Bucket by-order:0: Operation successful (remaining=4).
-	// Bucket by-order:0: Operation successful (remaining=3).
-	// Bucket by-order:0: Operation successful (remaining=2).
-	// Bucket by-order:0: Operation successful (remaining=1).
-	// Bucket by-order:0: Operation successful (remaining=0).
-	// Bucket by-order:0: FAILED. Rate limit exceeded.
-	// Bucket by-order:0: FAILED. Rate limit exceeded.
-	// Bucket by-order:0: FAILED. Rate limit exceeded.
-	// Bucket by-order:0: FAILED. Rate limit exceeded.
-	// Bucket by-order:1: Operation successful (remaining=5).
-	// Bucket by-order:1: Operation successful (remaining=4).
-	// Bucket by-order:1: Operation successful (remaining=3).
-	// Bucket by-order:1: Operation successful (remaining=2).
-	// Bucket by-order:1: Operation successful (remaining=1).
-	// Bucket by-order:1: Operation successful (remaining=0).
-	// Bucket by-order:1: FAILED. Rate limit exceeded.
-	// Bucket by-order:1: FAILED. Rate limit exceeded.
-	// Bucket by-order:1: FAILED. Rate limit exceeded.
-	// Bucket by-order:1: FAILED. Rate limit exceeded.
+	// Iteration  0; bucket by-order:0: Operation successful (remaining=5).
+	// Iteration  1; bucket by-order:0: Operation successful (remaining=4).
+	// Iteration  2; bucket by-order:0: Operation successful (remaining=3).
+	// Iteration  3; bucket by-order:0: Operation successful (remaining=2).
+	// Iteration  4; bucket by-order:0: Operation successful (remaining=1).
+	// Iteration  5; bucket by-order:0: Operation successful (remaining=0).
+	// Iteration  6; bucket by-order:0: FAILED. Rate limit exceeded.
+	// Iteration  7; bucket by-order:0: FAILED. Rate limit exceeded.
+	// Iteration  8; bucket by-order:0: FAILED. Rate limit exceeded.
+	// Iteration  9; bucket by-order:0: FAILED. Rate limit exceeded.
+	// Iteration 10; bucket by-order:1: Operation successful (remaining=5).
+	// Iteration 11; bucket by-order:1: Operation successful (remaining=4).
+	// Iteration 12; bucket by-order:1: Operation successful (remaining=3).
+	// Iteration 13; bucket by-order:1: Operation successful (remaining=2).
+	// Iteration 14; bucket by-order:1: Operation successful (remaining=1).
+	// Iteration 15; bucket by-order:1: Operation successful (remaining=0).
+	// Iteration 16; bucket by-order:1: FAILED. Rate limit exceeded.
+	// Iteration 17; bucket by-order:1: FAILED. Rate limit exceeded.
+	// Iteration 18; bucket by-order:1: FAILED. Rate limit exceeded.
+	// Iteration 19; bucket by-order:1: FAILED. Rate limit exceeded.
 }


### PR DESCRIPTION
Follows up #14. We already have an example based heavily around HTTP, so let's change the granular `GCRARateLimiter` usage example to one that isn't.

@metcalf Sorry for the extra noise here, but this follows up our discussion from earlier. The new example is still a little contrived, but it should serve to demonstrate the basics of direct usage.