### PR TITLE
Move regular build to 1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 language: go
 
 go:
-    - 1.3
+    - 1.7
     - tip
 
 notifications:

--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,7 @@ bench:
 
 lint:
 	gofmt -l .
-ifneq ($(TRAVIS_GO_VERSION),1.3)  # go vet doesn't play nicely on 1.3
 	go vet ./...
-endif
 	which golint # Fail if golint doesn't exist
 	-golint . # Don't fail on golint warnings themselves
 	-golint store # Don't fail on golint warnings themselves


### PR DESCRIPTION
Although the project itself is still stable under 1.3, it appears that
one of the dependencies that we're pulling in isn't (golint [1]).

Just for convenience sake, let's solve this the easy way by just moving
the regular build to 1.7 to get us back into the green.

[1] https://travis-ci.org/throttled/throttled/jobs/140151055