### PR TITLE
Never assign a Redis key's TTL to zero

### DIFF
--- a/store/redigostore/redigostore.go
+++ b/store/redigostore/redigostore.go
@@ -18,11 +18,7 @@ end
 if v ~= ARGV[1] then
   return 0
 end
-if ARGV[3] ~= "0" then
-  redis.call('setex', KEYS[1], ARGV[3], ARGV[2])
-else
-  redis.call('set', KEYS[1], ARGV[2])
-end
+redis.call('setex', KEYS[1], ARGV[3], ARGV[2])
 return 1
 `
 )
@@ -106,10 +102,17 @@ func (r *RedigoStore) SetIfNotExistsWithTTL(key string, value int64, ttl time.Du
 
 	updated := v == 1
 
-	if ttl >= time.Second {
-		if _, err := conn.Do("EXPIRE", key, int(ttl.Seconds())); err != nil {
-			return updated, err
-		}
+	ttlSeconds := int(ttl.Seconds())
+
+	// An `EXPIRE 0` will delete the key immediately, so make sure that we set
+	// expiry for a minimum of one second out so that our results stay in the
+	// store.
+	if ttlSeconds < 1 {
+		ttlSeconds = 1
+	}
+
+	if _, err := conn.Do("EXPIRE", key, ttlSeconds); err != nil {
+		return updated, err
 	}
 
 	return updated, nil
@@ -128,7 +131,16 @@ func (r *RedigoStore) CompareAndSwapWithTTL(key string, old, new int64, ttl time
 	}
 	defer conn.Close()
 
-	swapped, err := redis.Bool(conn.Do("EVAL", redisCASScript, 1, key, old, new, int(ttl.Seconds())))
+	ttlSeconds := int(ttl.Seconds())
+
+	// An `EXPIRE 0` will delete the key immediately, so make sure that we set
+	// expiry for a minimum of one second out so that our results stay in the
+	// store.
+	if ttlSeconds < 1 {
+		ttlSeconds = 1
+	}
+
+	swapped, err := redis.Bool(conn.Do("EVAL", redisCASScript, 1, key, old, new, ttlSeconds))
 	if err != nil {
 		if strings.Contains(err.Error(), redisCASMissingKey) {
 			return false, nil


### PR DESCRIPTION
It seems that under the current implementation we could run into a case
where the TTL is so short that we would never expire certain Redis keys
or might throw an error in the case of `SETEX`.

I think this is mostly relevant for extremely fast rates that would
replenish in less than second, so in practice probably not an issue that
most people would run into.

Here we just broaden the minimum horizon for an expiry out to one
second. Things should still work as expected because the proper TAT
value will still be in there if the key's checked after it should have
theoretically expired, and will also eventually be cleaned up by Redis.

Fixes #26.

@metcalf Can you double-check my work here?