### PR TITLE
Clarify limits with MaxBurst 0

### DIFF
--- a/rate.go
+++ b/rate.go
@@ -84,13 +84,15 @@ type Rate struct {
 
 // RateQuota describes the number of requests allowed per time period.
 // MaxRate specified the maximum sustained rate of requests and must
-// be greater than zero.  MaxBurst defines the number of requests that
+// be greater than zero. MaxBurst defines the number of requests that
 // will be allowed to exceed the rate in a single burst and must be
 // greater than or equal to zero.
 //
 // Rate{PerSec(1), 0} would mean that after each request, no more
-// requests will be permitted for that client for one second. In
-// practice, you probably want to set MaxBurst >0 to provide some
+// requests will be permitted for that client for one second.
+// Rate{PerSec(2), 0} permits one request per 0.5 seconds rather than
+// two requests in one second.
+// In practice, you probably want to set MaxBurst >0 to provide some
 // flexibility to clients that only need to make a handful of
 // requests. In fact a MaxBurst of zero will *never* permit a request
 // with a quantity greater than one because it will immediately exceed


### PR DESCRIPTION
This my humble attempt to help others avoid the same mistake I made when configuring throttled. With `MaxBurst = 0` it is best to imagine the limits as 1 per varying unit of time - instead of n per 1 second.
```
Rate{PerSec(1), 0} => 1 per second
Rate{PerSec(2), 0} => 1 per 0.5 seconds
Rate{PerSec(5), 0} => 1 per 0.2 seconds
```
So to allow 5 requests per second and to allow all of them to start at the same moment (this is the worst case) MaxBurst needs to be set to 4 to allow for 4 more requests in those first 0.2 seconds on top of the one that is allowed anyways.
