### PR TITLE
Stop using gopkg.in

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,10 @@ go:
     - 1.7
     - 1.8
     - 1.9
-    - tip
+    # 1.x builds the latest in that series. Also try to add other versions here
+    # as they come up so that we're pretty sure that we're maintaining
+    # backwards compatibility.
+    - 1.x
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ language: go
 
 go:
     - 1.7
+    - 1.8
+    - 1.9
     - tip
 
 notifications:
@@ -12,13 +14,6 @@ notifications:
 services:
   - redis-server
 
-install:
-  - make get-deps
-  # Move to the gopkg location that rather than the default clone location
-  # otherwise Go 1.4+ complains about incorrect import paths.
-  - export GOPKG_DIR=$GOPATH/src/gopkg.in/throttled
-  - mkdir -p $GOPKG_DIR
-  - mv $TRAVIS_BUILD_DIR $GOPKG_DIR/throttled.v2
-  - cd $GOPKG_DIR/throttled.v2
+install: make get-deps
 
 script: make

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Throttled [![build status](https://secure.travis-ci.org/throttled/throttled.svg)](https://travis-ci.org/throttled/throttled) [![GoDoc](https://godoc.org/gopkg.in/throttled/throttled.v2?status.svg)](https://godoc.org/gopkg.in/throttled/throttled.v2)
+# Throttled [![build status](https://secure.travis-ci.org/throttled/throttled.svg)](https://travis-ci.org/throttled/throttled) [![GoDoc](https://godoc.org/github.com/throttled/throttled?status.svg)](https://godoc.org/github.com/throttled/throttled)
 
 Package throttled implements rate limiting using the [generic cell rate
 algorithm][gcra] to limit access to resources such as HTTP endpoints.
@@ -11,8 +11,9 @@ what our users need. Thanks!
 
 ## Installation
 
-throttled uses gopkg.in for semantic versioning:
-`go get gopkg.in/throttled/throttled.v2`
+```sh
+go get -u github.com/throttled/throttled`
+```
 
 ## Documentation
 
@@ -41,33 +42,6 @@ httpRateLimiter := throttled.HTTPRateLimiter{
 http.ListenAndServe(":8080", httpRateLimiter.RateLimit(myHandler))
 ```
 
-## Contributing
-
-Since throttled uses gopkg.in for versioning, running `go get` against
-a fork or cloning from Github to the default path will break
-imports. Instead, use the following process for setting up your
-environment and contributing:
-
-```sh
-# Retrieve the source and dependencies.
-go get gopkg.in/throttled/throttled.v2/...
-
-# Fork the project on Github. For all following directions replace
-# <username> with your Github username. Add your fork as a remote.
-cd $GOPATH/src/gopkg.in/throttled/throttled.v2
-git remote add fork git@github.com:<username>/throttled.git
-
-# Create a branch, make your changes, test them and commit.
-git checkout -b my-new-feature
-# <do some work>
-make test 
-git commit -a
-git push -u fork my-new-feature
-```
-
-When your changes are ready, [open a pull request][pr] using "compare
-across forks".
-
 ## Related Projects
 
 See [throttled/gcra][throttled-gcra] for a list of other projects related to
@@ -79,7 +53,7 @@ The [BSD 3-clause license][bsd]. Copyright (c) 2014 Martin Angers and contributo
 
 [blog]: http://0value.com/throttled--guardian-of-the-web-server
 [bsd]: https://opensource.org/licenses/BSD-3-Clause
-[doc]: https://godoc.org/gopkg.in/throttled/throttled.v2
+[doc]: https://godoc.org/github.com/throttled/throttled
 [gcra]: https://en.wikipedia.org/wiki/Generic_cell_rate_algorithm
 [puerkitobio]: https://github.com/puerkitobio/
 [pr]: https://github.com/throttled/throttled/compare

--- a/deprecated_test.go
+++ b/deprecated_test.go
@@ -5,8 +5,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"gopkg.in/throttled/throttled.v2"
-	"gopkg.in/throttled/throttled.v2/store"
+	"github.com/throttled/throttled"
+	"github.com/throttled/throttled/store"
 )
 
 // Ensure that the current implementation remains compatible with the

--- a/doc.go
+++ b/doc.go
@@ -1,3 +1,3 @@
 // Package throttled implements rate limiting access to resources such
 // as HTTP endpoints.
-package throttled // import "gopkg.in/throttled/throttled.v2"
+package throttled // import "github.com/throttled/throttled"

--- a/example_test.go
+++ b/example_test.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"net/http"
 
-	"gopkg.in/throttled/throttled.v2"
-	"gopkg.in/throttled/throttled.v2/store/memstore"
+	"github.com/throttled/throttled"
+	"github.com/throttled/throttled/store/memstore"
 )
 
 var myHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/http_test.go
+++ b/http_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"gopkg.in/throttled/throttled.v2"
+	"github.com/throttled/throttled"
 )
 
 type stubLimiter struct {

--- a/rate_test.go
+++ b/rate_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"gopkg.in/throttled/throttled.v2"
-	"gopkg.in/throttled/throttled.v2/store/memstore"
+	"github.com/throttled/throttled"
+	"github.com/throttled/throttled/store/memstore"
 )
 
 const deniedStatus = 429

--- a/store/deprecated.go
+++ b/store/deprecated.go
@@ -1,11 +1,11 @@
 // Package store contains deprecated aliases for subpackages
-package store // import "gopkg.in/throttled/throttled.v2/store"
+package store // import "github.com/throttled/throttled/store"
 
 import (
 	"github.com/garyburd/redigo/redis"
 
-	"gopkg.in/throttled/throttled.v2/store/memstore"
-	"gopkg.in/throttled/throttled.v2/store/redigostore"
+	"github.com/throttled/throttled/store/memstore"
+	"github.com/throttled/throttled/store/redigostore"
 )
 
 // DEPRECATED. NewMemStore is a compatible alias for mem.New

--- a/store/memstore/memstore.go
+++ b/store/memstore/memstore.go
@@ -1,5 +1,5 @@
 // Package memstore offers an in-memory store implementation for throttled.
-package memstore // import "gopkg.in/throttled/throttled.v2/store/memstore"
+package memstore // import "github.com/throttled/throttled/store/memstore"
 
 import (
 	"sync"

--- a/store/memstore/memstore_test.go
+++ b/store/memstore/memstore_test.go
@@ -3,8 +3,8 @@ package memstore_test
 import (
 	"testing"
 
-	"gopkg.in/throttled/throttled.v2/store/memstore"
-	"gopkg.in/throttled/throttled.v2/store/storetest"
+	"github.com/throttled/throttled/store/memstore"
+	"github.com/throttled/throttled/store/storetest"
 )
 
 func TestMemStoreLRU(t *testing.T) {

--- a/store/redigostore/redigostore.go
+++ b/store/redigostore/redigostore.go
@@ -1,5 +1,5 @@
 // Package redigostore offers Redis-based store implementation for throttled using redigo.
-package redigostore // import "gopkg.in/throttled/throttled.v2/store/redigostore"
+package redigostore // import "github.com/throttled/throttled/store/redigostore"
 
 import (
 	"strings"

--- a/store/redigostore/redigostore_test.go
+++ b/store/redigostore/redigostore_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/garyburd/redigo/redis"
 
-	"gopkg.in/throttled/throttled.v2/store/redigostore"
-	"gopkg.in/throttled/throttled.v2/store/storetest"
+	"github.com/throttled/throttled/store/redigostore"
+	"github.com/throttled/throttled/store/storetest"
 )
 
 const (

--- a/store/storetest/doc.go
+++ b/store/storetest/doc.go
@@ -1,2 +1,2 @@
 // Package storetest provides a helper for testing throttled stores.
-package storetest // import "gopkg.in/throttled/throttled.v2/store/storetest"
+package storetest // import "github.com/throttled/throttled/store/storetest"

--- a/store/storetest/storetest.go
+++ b/store/storetest/storetest.go
@@ -1,5 +1,5 @@
 // Package storetest provides a helper for testing throttled stores.
-package storetest // import "gopkg.in/throttled/throttled.v2/store/storetest"
+package storetest // import "github.com/throttled/throttled/store/storetest"
 
 import (
 	"math/rand"
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"gopkg.in/throttled/throttled.v2"
+	"github.com/throttled/throttled"
 )
 
 // TestGCRAStore tests the behavior of a GCRAStore implementation for

--- a/varyby_test.go
+++ b/varyby_test.go
@@ -5,7 +5,7 @@ import (
 	"net/url"
 	"testing"
 
-	"gopkg.in/throttled/throttled.v2"
+	"github.com/throttled/throttled"
 )
 
 func TestVaryBy(t *testing.T) {


### PR DESCRIPTION
We originally used `gopkg.in` for the project because V2 introduced
significant breaking changes and providing a way to easily get the V1
API would allow users to continue using that without too much additional
work.

Since then, Go's dependency management systems have advanced somewhat,
especially with the imminent introduction of the new `dep` tool which
allows dependencies to be locked to Git tags. Because `gopkg.in` does
introduce some additional complexity around building and contributing to
the project, this patch drops it in favor of using Git tags combined
with a more modern dependency management tool like `dep`. The V1 API has
also been obsolete for two years now, so it's not likely too many people
are going to need access to it anyway.

My plan here is to get this pull request merged, then tag `master` as
`v2.1.0`.

Fixes #31.

@metcalf Mind taking a look at this one? Thanks!