### PR TITLE
Use named field names in composite literals

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ go:
     - 1.7
     - 1.8
     - 1.9
+    - "1.10"
     # 1.x builds the latest in that series. Also try to add other versions here
     # as they come up so that we're pretty sure that we're maintaining
     # backwards compatibility.

--- a/example_test.go
+++ b/example_test.go
@@ -23,7 +23,7 @@ func ExampleHTTPRateLimiter() {
 	}
 
 	// Maximum burst of 5 which refills at 20 tokens per minute.
-	quota := throttled.RateQuota{throttled.PerMin(20), 5}
+	quota := throttled.RateQuota{MaxRate: throttled.PerMin(20), MaxBurst: 5}
 
 	rateLimiter, err := throttled.NewGCRARateLimiter(store, quota)
 	if err != nil {
@@ -48,7 +48,7 @@ func ExampleGCRARateLimiter() {
 	}
 
 	// Maximum burst of 5 which refills at 1 token per hour.
-	quota := throttled.RateQuota{throttled.PerHour(1), 5}
+	quota := throttled.RateQuota{MaxRate: throttled.PerHour(1), MaxBurst: 5}
 
 	rateLimiter, err := throttled.NewGCRARateLimiter(store, quota)
 	if err != nil {

--- a/http_test.go
+++ b/http_test.go
@@ -16,11 +16,24 @@ type stubLimiter struct {
 func (sl *stubLimiter) RateLimit(key string, quantity int) (bool, throttled.RateLimitResult, error) {
 	switch key {
 	case "limit":
-		return true, throttled.RateLimitResult{-1, -1, -1, time.Minute}, nil
+		result := throttled.RateLimitResult{
+			Limit:      -1,
+			Remaining:  -1,
+			ResetAfter: -1,
+			RetryAfter: time.Minute,
+		}
+		return true, result, nil
 	case "error":
-		return false, throttled.RateLimitResult{}, errors.New("stubLimiter error")
+		result := throttled.RateLimitResult{}
+		return false, result, errors.New("stubLimiter error")
 	default:
-		return false, throttled.RateLimitResult{1, 2, time.Minute, -1}, nil
+		result := throttled.RateLimitResult{
+			Limit:      1,
+			Remaining:  2,
+			ResetAfter: time.Minute,
+			RetryAfter: -1,
+		}
+		return false, result, nil
 	}
 }
 

--- a/rate_test.go
+++ b/rate_test.go
@@ -38,7 +38,7 @@ func (ts *testStore) CompareAndSwapWithTTL(key string, old, new int64, ttl time.
 
 func TestRateLimit(t *testing.T) {
 	limit := 5
-	rq := throttled.RateQuota{throttled.PerSec(1), limit - 1}
+	rq := throttled.RateQuota{MaxRate: throttled.PerSec(1), MaxBurst: limit - 1}
 	start := time.Unix(0, 0)
 	cases := []struct {
 		now               time.Time
@@ -111,7 +111,7 @@ func TestRateLimit(t *testing.T) {
 }
 
 func TestRateLimitUpdateFailures(t *testing.T) {
-	rq := throttled.RateQuota{throttled.PerSec(1), 1}
+	rq := throttled.RateQuota{MaxRate: throttled.PerSec(1), MaxBurst: 1}
 	mst, err := memstore.New(0)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
As #35 was coming in, I noticed that as of Go 1.10, `go vet` complains
about the use of unkeyed fields in composite literals:

```
go vet ./...
./example_test.go:26: github.com/throttled/throttled.RateQuota composite literal uses unkeyed fields
./example_test.go:51: github.com/throttled/throttled.RateQuota composite literal uses unkeyed fields
./http_test.go:19: github.com/throttled/throttled.RateLimitResult composite literal uses unkeyed fields
./http_test.go:23: github.com/throttled/throttled.RateLimitResult composite literal uses unkeyed fields
./rate_test.go:41: github.com/throttled/throttled.RateQuota composite literal uses unkeyed fields
./rate_test.go:114: github.com/throttled/throttled.RateQuota composite literal uses unkeyed fields
```

Which is unfortunately failing the build for the `1.x` version.

This patch names fields wherever we were using the unkeyed kind.