### PR TITLE
Fixed a bug which occurrs when RemoteAddr is used

### DIFF
--- a/varyby.go
+++ b/varyby.go
@@ -53,7 +53,7 @@ func (vb *VaryBy) Key(r *http.Request) string {
 		sep = "\n" // Separator defaults to newline
 	}
 	if vb.RemoteAddr {
-		buf.WriteString(strings.ToLower(r.RemoteAddr) + sep)
+		buf.WriteString(strings.ToLower(r.RemoteAddr[:strings.Index(r.RemoteAddr, ":")]) + sep)
 	}
 	if vb.Method {
 		buf.WriteString(strings.ToLower(r.Method) + sep)


### PR DESCRIPTION
The HTTP server in the https://golang.org/pkg/net/http/ package sets RemoteAddr to an "IP:port" address before invoking a handler. The ":port" portion of the RemoteAddr prevents the throtteling from working as expected as soon as VaryBy{} contains "RemoteAddr: true". That's why we need to get rid of the port.