### PR TITLE
Fix `RemoteAddr` vary by to also handle IPv6

### DIFF
--- a/varyby.go
+++ b/varyby.go
@@ -53,7 +53,10 @@ func (vb *VaryBy) Key(r *http.Request) string {
 		sep = "\n" // Separator defaults to newline
 	}
 	if vb.RemoteAddr {
-		buf.WriteString(strings.ToLower(r.RemoteAddr[:strings.Index(r.RemoteAddr, ":")]) + sep)
+		// RemoteAddr looks something like `IP:port`. Something like
+		// `[::]:1234`.
+		ip := r.RemoteAddr[:strings.LastIndex(r.RemoteAddr, ":")]
+		buf.WriteString(strings.ToLower(ip) + sep)
 	}
 	if vb.Method {
 		buf.WriteString(strings.ToLower(r.Method) + sep)

--- a/varyby_test.go
+++ b/varyby_test.go
@@ -22,30 +22,35 @@ func TestVaryBy(t *testing.T) {
 		0: {nil, &http.Request{}, ""},
 		1: {
 			&throttled.VaryBy{RemoteAddr: true},
-			&http.Request{RemoteAddr: "1.2.3.4:1234"},
+			&http.Request{RemoteAddr: "1.2.3.4:1234"}, // IPv4
 			"1.2.3.4\n",
 		},
 		2: {
+			&throttled.VaryBy{RemoteAddr: true},
+			&http.Request{RemoteAddr: "[::]:1234"}, // IPv6
+			"[::]\n",
+		},
+		3: {
 			&throttled.VaryBy{Method: true, Path: true},
 			&http.Request{Method: "POST", URL: u},
 			"post\n/test/path\n",
 		},
-		3: {
+		4: {
 			&throttled.VaryBy{Headers: []string{"Content-length"}},
 			&http.Request{Header: http.Header{"Content-Type": []string{"text/plain"}, "Content-Length": []string{"123"}}},
 			"123\n",
 		},
-		4: {
+		5: {
 			&throttled.VaryBy{Separator: ",", Method: true, Headers: []string{"Content-length"}, Params: []string{"q", "user"}},
 			&http.Request{Method: "GET", Header: http.Header{"Content-Type": []string{"text/plain"}, "Content-Length": []string{"123"}}, Form: url.Values{"q": []string{"s"}, "pwd": []string{"secret"}, "user": []string{"test"}}},
 			"get,123,s,test,",
 		},
-		5: {
+		6: {
 			&throttled.VaryBy{Cookies: []string{"ssn"}},
 			&http.Request{Header: http.Header{"Cookie": []string{ck.String()}}},
 			"test\n",
 		},
-		6: {
+		7: {
 			&throttled.VaryBy{Cookies: []string{"ssn"}, RemoteAddr: true, Custom: func(r *http.Request) string {
 				return "blah"
 			}},


### PR DESCRIPTION
`RemoteAddr` vary by should also handle IPv6 addresses, which may have
colons of their own. I've added a test case that was copied from an
actual run of an HTTP server.

Fixes the change introduced in #45.