### PR TITLE
Do not attempt to use or slice RemoteAddr if its empty

### DIFF
--- a/varyby.go
+++ b/varyby.go
@@ -52,7 +52,7 @@ func (vb *VaryBy) Key(r *http.Request) string {
 	if sep == "" {
 		sep = "\n" // Separator defaults to newline
 	}
-	if vb.RemoteAddr {
+	if vb.RemoteAddr && len(r.RemoteAddr) > 0 {
 		// RemoteAddr looks something like `IP:port`. Something like
 		// `[::]:1234`.
 		ip := r.RemoteAddr[:strings.LastIndex(r.RemoteAddr, ":")]


### PR DESCRIPTION
Latest release caused a panic with the handling of `RemoteAdd`.