### PR TITLE
Add 1.11 to build matrix and drop 1.7 and 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,9 @@ sudo: false
 language: go
 
 go:
-    - 1.7
-    - 1.8
-    - 1.9
+    - "1.9"
     - "1.10"
+    - "1.11"
     # 1.x builds the latest in that series. Also try to add other versions here
     # as they come up so that we're pretty sure that we're maintaining
     # backwards compatibility.


### PR DESCRIPTION
Adds 1.11 to build the matrix.

Only the last two versions of Go are technically supported according to
the official policy (so 1.11 and 1.10). We should make an effort to
support old versions for longer than that, but probably not *too* big of
an effort because upgrading Go versions tends to be quite easy.

Here we drop 1.7 and 1.8 because Golint no longer supports them and
they're failing in our build matrix. We could exempt them from Golint,
but given the above, I think it's okay to drop them in this case
instead.