### PR TITLE
Handle `RemoteAddr` values that don't contain a port

### DIFF
--- a/varyby.go
+++ b/varyby.go
@@ -53,9 +53,18 @@ func (vb *VaryBy) Key(r *http.Request) string {
 		sep = "\n" // Separator defaults to newline
 	}
 	if vb.RemoteAddr && len(r.RemoteAddr) > 0 {
-		// RemoteAddr looks something like `IP:port`. Something like
-		// `[::]:1234`.
-		ip := r.RemoteAddr[:strings.LastIndex(r.RemoteAddr, ":")]
+		// RemoteAddr usually looks something like `IP:port`. For example,
+		// `[::]:1234`. However, it seems to occasionally degenerately appear
+		// as just IP (or other), so be conservative with how we extract it.
+		index := strings.LastIndex(r.RemoteAddr, ":")
+
+		var ip string
+		if index == -1 {
+			ip = r.RemoteAddr
+		} else {
+			ip = r.RemoteAddr[:index]
+		}
+
 		buf.WriteString(strings.ToLower(ip) + sep)
 	}
 	if vb.Method {

--- a/varyby_test.go
+++ b/varyby_test.go
@@ -31,26 +31,32 @@ func TestVaryBy(t *testing.T) {
 			"[::]\n",
 		},
 		3: {
+			// Don't panic in case RemoteAddr doesn't contain a port.
+			&throttled.VaryBy{RemoteAddr: true},
+			&http.Request{RemoteAddr: "1.2.3.4"},
+			"1.2.3.4\n",
+		},
+		4: {
 			&throttled.VaryBy{Method: true, Path: true},
 			&http.Request{Method: "POST", URL: u},
 			"post\n/test/path\n",
 		},
-		4: {
+		5: {
 			&throttled.VaryBy{Headers: []string{"Content-length"}},
 			&http.Request{Header: http.Header{"Content-Type": []string{"text/plain"}, "Content-Length": []string{"123"}}},
 			"123\n",
 		},
-		5: {
+		6: {
 			&throttled.VaryBy{Separator: ",", Method: true, Headers: []string{"Content-length"}, Params: []string{"q", "user"}},
 			&http.Request{Method: "GET", Header: http.Header{"Content-Type": []string{"text/plain"}, "Content-Length": []string{"123"}}, Form: url.Values{"q": []string{"s"}, "pwd": []string{"secret"}, "user": []string{"test"}}},
 			"get,123,s,test,",
 		},
-		6: {
+		7: {
 			&throttled.VaryBy{Cookies: []string{"ssn"}},
 			&http.Request{Header: http.Header{"Cookie": []string{ck.String()}}},
 			"test\n",
 		},
-		7: {
+		8: {
 			&throttled.VaryBy{Cookies: []string{"ssn"}, RemoteAddr: true, Custom: func(r *http.Request) string {
 				return "blah"
 			}},


### PR DESCRIPTION
This isn't a documented occurrence as far as I can tell, but #51 reports
that it's possible. Either way, this is not a value that an attacker can
manipulate, so it makes to be conservative in how we handle it.

Fixes #51.