### PR TITLE
Add Go 1.12, 1.13 to build matrix; drop 1.9, 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ sudo: false
 language: go
 
 go:
-    - "1.9"
-    - "1.10"
     - "1.11"
+    - "1.12"
+    - "1.13"
     # 1.x builds the latest in that series. Also try to add other versions here
     # as they come up so that we're pretty sure that we're maintaining
     # backwards compatibility.


### PR DESCRIPTION
Adds newer versions of Go 1.12 and 1.13 to the Travis build matrix.

We also drop 1.9 and 1.10 -- unfortunately, go-redis has gone entirely
in on Go modules and doesn't work without them anymore. They were first
introduced in Go 1.11, so only our builds in 1.11+ are working.

There's probably a workaround we could use to keep the old versions
building, but it's not worth it. Throttled should still work fine on
these older versions even if they're not in the matrix, and Go users
tend to be pretty good about keeping their Go up-to-date anyway, so I
doubt we'll be affecting many people.