### PR TITLE
Fail build on Lint failure + fix lint + use deprecated convention

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,8 @@ bench:
 lint:
 	gofmt -l .
 	go vet ./...
-	which golint # Fail if golint doesn't exist
-	-golint . # Don't fail on golint warnings themselves
-	-golint store # Don't fail on golint warnings themselves
+	which golint
+	golint -set_exit_status ./...
 
 get-deps:
 	go get github.com/gomodule/redigo/redis

--- a/deprecated.go
+++ b/deprecated.go
@@ -5,41 +5,55 @@ import (
 	"time"
 )
 
-// DEPRECATED. Quota returns the number of requests allowed and the custom time window.
+// Quota returns the number of requests allowed and the custom time window.
+//
+// Deprecated: Use Rate and RateLimiter instead.
 func (q Rate) Quota() (int, time.Duration) {
 	return q.count, q.period * time.Duration(q.count)
 }
 
-// DEPRECATED. Q represents a custom quota.
+// Q represents a custom quota.
+//
+// Deprecated: Use Rate and RateLimiter instead.
 type Q struct {
 	Requests int
 	Window   time.Duration
 }
 
-// DEPRECATED. Quota returns the number of requests allowed and the custom time window.
+// Quota returns the number of requests allowed and the custom time window.
+//
+// Deprecated: Use Rate and RateLimiter instead.
 func (q Q) Quota() (int, time.Duration) {
 	return q.Requests, q.Window
 }
 
-// DEPRECATED. The Quota interface defines the method to implement to describe
+// The Quota interface defines the method to implement to describe
 // a time-window quota, as required by the RateLimit throttler.
+//
+// Deprecated: Use Rate and RateLimiter instead.
 type Quota interface {
 	// Quota returns a number of requests allowed, and a duration.
 	Quota() (int, time.Duration)
 }
 
-// DEPRECATED. Throttler is a backwards-compatible alias for HTTPLimiter.
+// Throttler is a backwards-compatible alias for HTTPLimiter.
+//
+// Deprecated: Use Rate and RateLimiter instead.
 type Throttler struct {
 	HTTPRateLimiter
 }
 
-// DEPRECATED. Throttle is an alias for HTTPLimiter#Limit
+// Throttle is an alias for HTTPLimiter#Limit
+//
+// Deprecated: Use Rate and RateLimiter instead.
 func (t *Throttler) Throttle(h http.Handler) http.Handler {
 	return t.RateLimit(h)
 }
 
-// DEPRECATED. RateLimit creates a Throttler that conforms to the given
+// RateLimit creates a Throttler that conforms to the given
 // rate limits
+//
+// Deprecated: Use Rate and RateLimiter instead.
 func RateLimit(q Quota, vary *VaryBy, store GCRAStore) *Throttler {
 	count, period := q.Quota()
 
@@ -67,7 +81,9 @@ func RateLimit(q Quota, vary *VaryBy, store GCRAStore) *Throttler {
 	}
 }
 
-// DEPRECATED. Store is an alias for GCRAStore
+// Store is an alias for GCRAStore
+//
+// Deprecated: Use Rate and RateLimiter instead.
 type Store interface {
 	GCRAStore
 }

--- a/rate.go
+++ b/rate.go
@@ -141,10 +141,10 @@ type GCRARateLimiter struct {
 // only permits one request per second with no tolerance for bursts.
 func NewGCRARateLimiter(st GCRAStore, quota RateQuota) (*GCRARateLimiter, error) {
 	if quota.MaxBurst < 0 {
-		return nil, fmt.Errorf("Invalid RateQuota %#v. MaxBurst must be greater than zero.", quota)
+		return nil, fmt.Errorf("invalid RateQuota %#v; MaxBurst must be greater than zero", quota)
 	}
 	if quota.MaxRate.period <= 0 {
-		return nil, fmt.Errorf("Invalid RateQuota %#v. MaxRate must be greater than zero.", quota)
+		return nil, fmt.Errorf("invalid RateQuota %#v; MaxRate must be greater than zero", quota)
 	}
 
 	return &GCRARateLimiter{

--- a/store/deprecated.go
+++ b/store/deprecated.go
@@ -8,7 +8,9 @@ import (
 	"github.com/throttled/throttled/store/redigostore"
 )
 
-// DEPRECATED. NewMemStore is a compatible alias for mem.New
+// NewMemStore initializes a new memory-based store.
+//
+// Deprecated: Use github.com/throttled/throttled/store/memstore instead.
 func NewMemStore(maxKeys int) *memstore.MemStore {
 	st, err := memstore.New(maxKeys)
 	if err != nil {
@@ -19,7 +21,9 @@ func NewMemStore(maxKeys int) *memstore.MemStore {
 	return st
 }
 
-// DEPRECATED. NewMemStore is a compatible alias for redis.New
+// NewRedisStore initializes a new Redigo-based store.
+//
+// Deprecated: Use github.com/throttled/throttled/store/redigostore instead.
 func NewRedisStore(pool *redis.Pool, keyPrefix string, db int) *redigostore.RedigoStore {
 	st, err := redigostore.New(pool, keyPrefix, db)
 	if err != nil {


### PR DESCRIPTION
Introduces a few changes:

* We now fail the build on lint failure with `-set_exit_status`, an
  option that wasn't available when the bulk of this library was written.

* To make that possible, we fix a few minor linting problems.

* The main class of lint fix is to move over to use the recommended Go
  `Deprecated: ` comment [1], which replaces our start-of-comment
  deprecated comments, which allows docstrings to be in-line with Go's
  conventions.

[1] https://github.com/golang/go/wiki/Deprecated