### PR TITLE
Fix TTL in SetIfNotExistsWithTTL

### DIFF
--- a/store/goredisstore/goredisstore.go
+++ b/store/goredisstore/goredisstore.go
@@ -89,16 +89,14 @@ func (r *GoRedisStore) SetIfNotExistsWithTTL(key string, value int64, ttl time.D
 		return false, err
 	}
 
-	ttlSeconds := time.Duration(ttl.Seconds())
-
 	// An `EXPIRE 0` will delete the key immediately, so make sure that we set
 	// expiry for a minimum of one second out so that our results stay in the
 	// store.
-	if ttlSeconds < 1 {
-		ttlSeconds = 1
+	if ttl < 1*time.Second {
+		ttl = 1 * time.Second
 	}
 
-	err = r.client.Expire(context, key, ttlSeconds*time.Second).Err()
+	err = r.client.Expire(context, key, ttl).Err()
 	return updated, err
 }
 


### PR DESCRIPTION
Hi :wave:

I think I've found a bug in the `SetIfNotExistsWithTTL` function.

A `time.Duration` represents the time as an `int64` nanosecond count ([godoc](https://pkg.go.dev/time?tab=doc#Duration)). However, we're currently creating a `time.Duration` from `ttl.Seconds`. Effectively, creating a new time.Duration 1,000,000,000 times smaller than the orginal ttl, as we're interpreting the seconds as nanoseconds.

The following playground example illustrates this: https://play.golang.org/p/8w15MOkAfC3