### PR TITLE
Add context objects to goredis calls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 language: go
 
 go:
-    - "1.11"
     - "1.12"
     - "1.13"
     # 1.x builds the latest in that series. Also try to add other versions here

--- a/store/goredisstore/goredisstore_test.go
+++ b/store/goredisstore/goredisstore_test.go
@@ -1,6 +1,7 @@
 package goredisstore_test
 
 import (
+	"context"
 	"log"
 	"testing"
 	"time"
@@ -62,12 +63,14 @@ func BenchmarkRedisStore(b *testing.B) {
 }
 
 func clearRedis(c *redis.Client) error {
-	keys, err := c.Keys(redisTestPrefix + "*").Result()
+	context := context.Background()
+
+	keys, err := c.Keys(context, redisTestPrefix + "*").Result()
 	if err != nil {
 		return err
 	}
 
-	return c.Del(keys...).Err()
+	return c.Del(context, keys...).Err()
 }
 
 func setupRedis(tb testing.TB, ttl time.Duration) (*redis.Client, *goredisstore.GoRedisStore) {
@@ -79,7 +82,7 @@ func setupRedis(tb testing.TB, ttl time.Duration) (*redis.Client, *goredisstore.
 		DB:          redisTestDB, // use default DB
 	})
 
-	if err := client.Ping().Err(); err != nil {
+	if err := client.Ping(context.Background()).Err(); err != nil {
 		client.Close()
 		tb.Skip("redis server not available on localhost port 6379")
 	}

--- a/store/goredisstore/goredisstore_test.go
+++ b/store/goredisstore/goredisstore_test.go
@@ -65,7 +65,7 @@ func BenchmarkRedisStore(b *testing.B) {
 func clearRedis(c *redis.Client) error {
 	context := context.Background()
 
-	keys, err := c.Keys(context, redisTestPrefix + "*").Result()
+	keys, err := c.Keys(context, redisTestPrefix+"*").Result()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The build is currently broken because goredis changed their API in a few
ways -- mostly adding context objects to all calls, but also with a few
minor type changes.

We'll want to have a better versioning strategy at some point here, but
for now, we update our goredis adapter to be compatible.