### PR TITLE
Add GitHub Actions and simplify the Makefile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,90 @@
+name: throttled CI
+
+on:
+  pull_request:
+  push:
+  schedule:
+    # once a day at 08:00
+    - cron: "0 8 * * *"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    env:
+      GOPATH: "/home/runner/work/throttled/throttled/go"
+
+      # This isn't great, but the interplay between GitHub Actions' Go action
+      # and pre-Go Modules projects is *very* bad and doesn't work out of the
+      # box. I've hacked my way around it here by specifying a GOPATH inside of
+      # GITHUB_WORKSPACE, checking out to an appropriate place in it, then
+      # explicitly specifying a working directory for every single Go-related
+      # step.
+      #
+      # The reason it's nested so deeply is that actions/checkout@v2 will only
+      # allow a path relative to `/home/runner/work/throttled/throttled/`.
+      #
+      # All of this can be ripped out once the project is on Go Modules.
+      WORKING_DIRECTORY: "/home/runner/work/throttled/throttled/go/src/github.com/throttled/throttled"
+
+    strategy:
+      matrix:
+        go:
+          - 1.12.x
+          - 1.13.x
+          - 1.14.x
+
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go }}
+
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          path: ${{ env.WORKING_DIRECTORY }}
+
+      - name: Debug
+        run: |
+          echo "github.ref=${{ github.ref }}"
+          echo "go env GOPATH=$(go env GOPATH)"
+          echo "pwd=$(pwd)"
+          echo "HOME=${HOME}"
+          echo "GITHUB_WORKSPACE=${GITHUB_WORKSPACE}"
+          echo "WORKING_DIRECTORY=${WORKING_DIRECTORY}"
+
+      - name: Install dependencies
+        run: make get-deps
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+
+      - name: "Go: Build"
+        run: go build ./...
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+
+      - name: "Go: Test"
+        run: go test -v ./...
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+
+      - name: "Go: Test (with `-race` and `-bench`)"
+        run: go test -race -bench=. -cpu=1,2,4
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+
+      - name: "Go: Test (with coverage)"
+        run: |
+          go test -coverprofile=throttled.coverage.out .
+          go test -coverprofile=store.coverage.out ./store
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+
+      - name: "Go: Vet"
+        run: go vet ./...
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+
+      - name: "Check: Gofmt"
+        run: scripts/check_gofmt.sh
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+
+      - name: "Check: Lint"
+        run: "$(go env GOPATH)/bin/golint -set_exit_status ./..."
+        working-directory: ${{ env.WORKING_DIRECTORY }}

--- a/Makefile
+++ b/Makefile
@@ -1,29 +1,29 @@
+.PHONY: all
+all: build test vet fmt lint
 
+.PHONY: build
+build:
+	go build ./...
 
-.PHONY: test test-cover bench lint get-deps .go-test .go-test-cover
+.PHONY: fmt
+fmt:
+	scripts/check_gofmt.sh
 
-test: .go-test bench lint
-
-test-cover: .go-test-cover bench lint
-
-bench:
-	go test -race -bench=. -cpu=1,2,4
-
-lint:
-	gofmt -l .
-	go vet ./...
-	which golint
-	golint -set_exit_status ./...
-
+.PHONY: get-deps
 get-deps:
 	go get github.com/gomodule/redigo/redis
 	go get github.com/hashicorp/golang-lru
 	go get golang.org/x/lint/golint
 	go get github.com/go-redis/redis
 
-.go-test:
+.PHONY: lint
+lint:
+	golint -set_exit_status ./...
+
+.PHONY: test
+test:
 	go test ./...
 
-.go-test-cover:
-	go test -coverprofile=throttled.coverage.out .
-	go test -coverprofile=store.coverage.out ./store
+.PHONY: vet
+vet:
+	go vet ./...

--- a/scripts/check_gofmt.sh
+++ b/scripts/check_gofmt.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+find_files() {
+  find . -not \( \
+      \( \
+        -name 'vendor' \
+      \) -prune \
+    \) -name '*.go'
+}
+
+bad_files=$(find_files | xargs gofmt -s -l)
+if [[ -n "${bad_files}" ]]; then
+    echo "!!! gofmt needs to be run on the following files: "
+    echo "${bad_files}"
+    exit 1
+fi


### PR DESCRIPTION
Adds a configuration file for GitHub Actions, which is largely based on
the CI runs that we're doing with Travis today.

I also modified the `Makefile` to improve it somewhat. Mainly:

* Tease apart its weirdness around grouping somewhat unrelated things
  into single buckets (vet, lint, fmt all together as `lint`).

* Move a few tasks out of the `Makefile` that are unlikely to ever be
  invoked by a user. These are called from GitHub Actions manually
  instead.

* Add a script for invoking `gofmt` so that the build will actually fail
  when there's a formatting problem.

* Add an explicit `all` target.

* Move `.PHONY` invocations to above each target.