### PR TITLE
Redigo: Always select a DB when procuring connection

### DIFF
--- a/store/redigostore/redigostore.go
+++ b/store/redigostore/redigostore.go
@@ -157,11 +157,9 @@ func (r *RedigoStore) getConn() (redis.Conn, error) {
 	conn := r.pool.Get()
 
 	// Select the specified database
-	if r.db > 0 {
-		if _, err := redis.String(conn.Do("SELECT", r.db)); err != nil {
-			conn.Close()
-			return nil, err
-		}
+	if _, err := redis.String(conn.Do("SELECT", r.db)); err != nil {
+		conn.Close()
+		return nil, err
 	}
 
 	return conn, nil


### PR DESCRIPTION
Previously, we'd only selecting a DB when configured with one that was
non-0.

As reported in #70, this can be a problem if another subroutine using
the same pool changed a connection's DB and checked it back in. If that
were to occur and Throttled was configured with a DB of 0, then we'd end
up using the wrong DB. This is made possible because the Redigo adapter
allows a pool to be injected, so that pool may certainly be used
elsewhere.

Here we remove the conditional around the `SELECT` command and just
have it always run.

Fixes #70.