### PR TITLE
Introduce context.Context in function signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ func myHandlerFunc(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
-	store, err := memstore.New(65536)
+	store, err := memstore.NewCtx(65536)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -74,12 +74,12 @@ func main() {
 		MaxRate:  throttled.PerMin(20),
 		MaxBurst: 5,
 	}
-	rateLimiter, err := throttled.NewGCRARateLimiter(store, quota)
+	rateLimiter, err := throttled.NewGCRARateLimiterCtx(store, quota)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	httpRateLimiter := throttled.HTTPRateLimiter{
+	httpRateLimiter := throttled.HTTPRateLimiterCtx{
 		RateLimiter: rateLimiter,
 		VaryBy:      &throttled.VaryBy{Path: true},
 	}
@@ -88,6 +88,16 @@ func main() {
 	http.ListenAndServe(":8080", httpRateLimiter.RateLimit(handler))
 }
 ```
+
+### Upgrading to `context.Context` aware version of `throttled`
+To upgrade to the new `context.Context` aware version of `throttled`, update the package to the latest version and replace the following function with their context-aware equivalent:
+- `memstore.New` => `memstore.NewCtx`
+- `goredisstore.New` => `goredisstore.NewCtx`
+- `redigostore.New` => `redigostore.NewCtx`
+- `throttled.NewGCRARateLimiter` => `throttled.NewGCRARateLimiterCtx`
+- `throttled.HTTPRateLimiter` => `throttled.HTTPRateLimiterCtx`
+
+Please note that not all stores make use of the passed `context.Context` yet.
 
 ## Related Projects
 

--- a/deprecated.go
+++ b/deprecated.go
@@ -1,6 +1,7 @@
 package throttled
 
 import (
+	"context"
 	"net/http"
 	"time"
 )
@@ -65,7 +66,7 @@ func RateLimit(q Quota, vary *VaryBy, store GCRAStore) *Throttler {
 	}
 
 	rate := Rate{period: period / time.Duration(count)}
-	limiter, err := NewGCRARateLimiter(store, RateQuota{rate, count - 1})
+	limiter, err := NewGCRARateLimiterCtx(WrapStoreWithContext(store), RateQuota{rate, count - 1})
 
 	// This panic in unavoidable because the original interface does
 	// not support returning an error.
@@ -86,4 +87,123 @@ func RateLimit(q Quota, vary *VaryBy, store GCRAStore) *Throttler {
 // Deprecated: Use Rate and RateLimiter instead.
 type Store interface {
 	GCRAStore
+}
+
+// HTTPRateLimiter is an adapter for HTTPRateLimiterCtx to provide backwards
+// compatibility.
+//
+// Deprecated: Use HTTPRateLimiterCtx instead. If the used RateLimiter does
+// not implement RateLimiterCtx, wrap it with WrapRateLimiterWithContext().
+type HTTPRateLimiter struct {
+	// DeniedHandler is called if the request is disallowed. If it is
+	// nil, the DefaultDeniedHandler variable is used.
+	DeniedHandler http.Handler
+
+	// Error is called if the RateLimiter returns an error. If it is
+	// nil, the DefaultErrorFunc is used.
+	Error func(w http.ResponseWriter, r *http.Request, err error)
+
+	// Limiter is call for each request to determine whether the
+	// request is permitted and update internal state. It must be set.
+	RateLimiter RateLimiter
+
+	// VaryBy is called for each request to generate a key for the
+	// limiter. If it is nil, all requests use an empty string key.
+	VaryBy interface {
+		Key(*http.Request) string
+	}
+}
+
+// RateLimit provides an adapter for HTTPRateLimiterCtx.RateLimit.
+//
+// Deprecated: Use HTTPRateLimiterCtx instead
+func (t *HTTPRateLimiter) RateLimit(h http.Handler) http.Handler {
+	l := HTTPRateLimiterCtx{
+		DeniedHandler: t.DeniedHandler,
+		Error:         t.Error,
+		RateLimiter:   WrapRateLimiterWithContext(t.RateLimiter),
+		VaryBy:        t.VaryBy,
+	}
+	return l.RateLimit(h)
+}
+
+// GCRAStore is the version of GCRAStoreCtx that is not aware of context.
+//
+// Deprecated: Implement GCRAStoreCtx instead.
+type GCRAStore interface {
+	GetWithTime(key string) (int64, time.Time, error)
+	SetIfNotExistsWithTTL(key string, value int64, ttl time.Duration) (bool, error)
+	CompareAndSwapWithTTL(key string, old, new int64, ttl time.Duration) (bool, error)
+}
+
+// NewGCRARateLimiter is a backwards compatible adapter for NewGCRARateLimiterCtx.
+//
+// Deprecated: Use NewGCRARateLimiterCtx instead. If the used store does
+// not implement GCRAStoreCtx, wrap it with WrapStoreWithContext().
+func NewGCRARateLimiter(st GCRAStore, quota RateQuota) (*GCRARateLimiterCtx, error) {
+	return NewGCRARateLimiterCtx(WrapStoreWithContext(st), quota)
+}
+
+// A RateLimiter manages limiting the rate of actions by key.
+//
+// Deprecated: Use RateLimiterCtx instead.
+type RateLimiter interface {
+	// RateLimit checks whether a particular key has exceeded a rate
+	// limit. It also returns a RateLimitResult to provide additional
+	// information about the state of the RateLimiter.
+	//
+	// If the rate limit has not been exceeded, the underlying storage
+	// is updated by the supplied quantity. For example, a quantity of
+	// 1 might be used to rate limit a single request while a greater
+	// quantity could rate limit based on the size of a file upload in
+	// megabytes. If quantity is 0, no update is performed allowing
+	// you to "peek" at the state of the RateLimiter for a given key.
+	RateLimit(key string, quantity int) (bool, RateLimitResult, error)
+}
+
+// RateLimit is provided as a backwards compatible variant of RateLimitCtx.
+//
+// Deprecated: Use RateLimitCtx instead.
+func (g *GCRARateLimiterCtx) RateLimit(key string, quantity int) (bool, RateLimitResult, error) {
+	return g.RateLimitCtx(context.Background(), key, quantity)
+}
+
+// WrapStoreWithContext can be used to use GCRAStore in a place where a GCRAStoreCtx is required.
+func WrapStoreWithContext(store GCRAStore) GCRAStoreCtx {
+	return gcraStoreCtxAdapter{
+		gcraStore: store,
+	}
+}
+
+// WrapRateLimiterWithContext can be used to use RateLimiter in a place where a RateLimiterCtx is required.
+func WrapRateLimiterWithContext(rateLimier RateLimiter) RateLimiterCtx {
+	return rateLimiterCtxAdapter{
+		rateLimiter: rateLimier,
+	}
+}
+
+// gcraStoreCtxAdapter is an adapter that is used to use a GCRAStore where a GCRAStoreCtx is required.
+type gcraStoreCtxAdapter struct {
+	gcraStore GCRAStore
+}
+
+func (g gcraStoreCtxAdapter) GetWithTime(_ context.Context, key string) (int64, time.Time, error) {
+	return g.gcraStore.GetWithTime(key)
+}
+
+func (g gcraStoreCtxAdapter) SetIfNotExistsWithTTL(_ context.Context, key string, value int64, ttl time.Duration) (bool, error) {
+	return g.gcraStore.SetIfNotExistsWithTTL(key, value, ttl)
+}
+
+func (g gcraStoreCtxAdapter) CompareAndSwapWithTTL(_ context.Context, key string, old, new int64, ttl time.Duration) (bool, error) {
+	return g.gcraStore.CompareAndSwapWithTTL(key, old, new, ttl)
+}
+
+// rateLimiterCtxAdapter is an adapter that is used to use a RateLimiter where a RateLimiterCtx is required.
+type rateLimiterCtxAdapter struct {
+	rateLimiter RateLimiter
+}
+
+func (r rateLimiterCtxAdapter) RateLimitCtx(_ context.Context, key string, quantity int) (bool, RateLimitResult, error) {
+	return r.rateLimiter.RateLimit(key, quantity)
 }

--- a/http.go
+++ b/http.go
@@ -22,7 +22,7 @@ var (
 	}
 )
 
-// HTTPRateLimiter faciliates using a Limiter to limit HTTP requests.
+// HTTPRateLimiterCtx facilitates using a Limiter to limit HTTP requests.
 type HTTPRateLimiterCtx struct {
 	// DeniedHandler is called if the request is disallowed. If it is
 	// nil, the DefaultDeniedHandler variable is used.

--- a/http_test.go
+++ b/http_test.go
@@ -1,6 +1,7 @@
 package throttled_test
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -13,7 +14,7 @@ import (
 type stubLimiter struct {
 }
 
-func (sl *stubLimiter) RateLimit(key string, quantity int) (bool, throttled.RateLimitResult, error) {
+func (sl *stubLimiter) RateLimitCtx(_ context.Context, key string, quantity int) (bool, throttled.RateLimitResult, error) {
 	switch key {
 	case "limit":
 		result := throttled.RateLimitResult{
@@ -50,7 +51,7 @@ type httpTestCase struct {
 }
 
 func TestHTTPRateLimiter(t *testing.T) {
-	limiter := throttled.HTTPRateLimiter{
+	limiter := throttled.HTTPRateLimiterCtx{
 		RateLimiter: &stubLimiter{},
 		VaryBy:      &pathGetter{},
 	}
@@ -67,7 +68,7 @@ func TestHTTPRateLimiter(t *testing.T) {
 }
 
 func TestCustomHTTPRateLimiterHandlers(t *testing.T) {
-	limiter := throttled.HTTPRateLimiter{
+	limiter := throttled.HTTPRateLimiterCtx{
 		RateLimiter: &stubLimiter{},
 		VaryBy:      &pathGetter{},
 		DeniedHandler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -112,7 +113,7 @@ func runHTTPTestCases(t *testing.T, h http.Handler, cs []httpTestCase) {
 }
 
 func BenchmarkHTTPRateLimiter(b *testing.B) {
-	limiter := throttled.HTTPRateLimiter{
+	limiter := throttled.HTTPRateLimiterCtx{
 		RateLimiter: &stubLimiter{},
 		VaryBy:      &pathGetter{},
 	}

--- a/rate.go
+++ b/rate.go
@@ -1,6 +1,7 @@
 package throttled
 
 import (
+	"context"
 	"fmt"
 	"time"
 )
@@ -12,7 +13,7 @@ const (
 )
 
 // A RateLimiter manages limiting the rate of actions by key.
-type RateLimiter interface {
+type RateLimiterCtx interface {
 	// RateLimit checks whether a particular key has exceeded a rate
 	// limit. It also returns a RateLimitResult to provide additional
 	// information about the state of the RateLimiter.
@@ -23,7 +24,7 @@ type RateLimiter interface {
 	// quantity could rate limit based on the size of a file upload in
 	// megabytes. If quantity is 0, no update is performed allowing
 	// you to "peek" at the state of the RateLimiter for a given key.
-	RateLimit(key string, quantity int) (bool, RateLimitResult, error)
+	RateLimitCtx(ctx context.Context, key string, quantity int) (bool, RateLimitResult, error)
 }
 
 // RateLimitResult represents the state of the RateLimiter for a
@@ -116,11 +117,11 @@ func PerDay(n int) Rate { return Rate{24 * time.Hour / time.Duration(n), n} }
 // PerDuration represents a number of requests per provided duration.
 func PerDuration(n int, d time.Duration) Rate { return Rate{d / time.Duration(n), n} }
 
-// GCRARateLimiter is a RateLimiter that uses the generic cell-rate
+// GCRARateLimiterCtx is a RateLimiter that uses the generic cell-rate
 // algorithm. The algorithm has been slightly modified from its usual
 // form to support limiting with an additional quantity parameter, such
 // as for limiting the number of bytes uploaded.
-type GCRARateLimiter struct {
+type GCRARateLimiterCtx struct {
 	limit int
 
 	// Think of the DVT as our flexibility:
@@ -133,20 +134,20 @@ type GCRARateLimiter struct {
 	// think of it as how frequently the bucket leaks one unit.
 	emissionInterval time.Duration
 
-	store GCRAStore
+	store GCRAStoreCtx
 
 	// Maximum number of times to retry SetIfNotExists/CompareAndSwap operations
 	// before returning an error.
 	maxCASAttemptsLimit int
 }
 
-// NewGCRARateLimiter creates a GCRARateLimiter. quota.Count defines
+// NewGCRARateLimiterCtx creates a GCRARateLimiterCtx. quota.Count defines
 // the maximum number of requests permitted in an instantaneous burst
 // and quota.Count / quota.Period defines the maximum sustained
 // rate. For example, PerMin(60) permits 60 requests instantly per key
 // followed by one request per second indefinitely whereas PerSec(1)
 // only permits one request per second with no tolerance for bursts.
-func NewGCRARateLimiter(st GCRAStore, quota RateQuota) (*GCRARateLimiter, error) {
+func NewGCRARateLimiterCtx(st GCRAStoreCtx, quota RateQuota) (*GCRARateLimiterCtx, error) {
 	if quota.MaxBurst < 0 {
 		return nil, fmt.Errorf("invalid RateQuota %#v; MaxBurst must be greater than zero", quota)
 	}
@@ -154,7 +155,7 @@ func NewGCRARateLimiter(st GCRAStore, quota RateQuota) (*GCRARateLimiter, error)
 		return nil, fmt.Errorf("invalid RateQuota %#v; MaxRate must be greater than zero", quota)
 	}
 
-	return &GCRARateLimiter{
+	return &GCRARateLimiterCtx{
 		delayVariationTolerance: quota.MaxRate.period * (time.Duration(quota.MaxBurst) + 1),
 		emissionInterval:        quota.MaxRate.period,
 		limit:                   quota.MaxBurst + 1,
@@ -179,7 +180,7 @@ func (g *GCRARateLimiter) SetMaxCASAttemptsLimit(limit int) {
 // quantity could rate limit based on the size of a file upload in
 // megabytes. If quantity is 0, no update is performed allowing you
 // to "peek" at the state of the RateLimiter for a given key.
-func (g *GCRARateLimiter) RateLimit(key string, quantity int) (bool, RateLimitResult, error) {
+func (g *GCRARateLimiterCtx) RateLimitCtx(ctx context.Context, key string, quantity int) (bool, RateLimitResult, error) {
 	var tat, newTat, now time.Time
 	var ttl time.Duration
 	rlc := RateLimitResult{Limit: g.limit, RetryAfter: -1}
@@ -193,7 +194,7 @@ func (g *GCRARateLimiter) RateLimit(key string, quantity int) (bool, RateLimitRe
 
 		// tat refers to the theoretical arrival time that would be expected
 		// from equally spaced requests at exactly the rate limit.
-		tatVal, now, err = g.store.GetWithTime(key)
+		tatVal, now, err = g.store.GetWithTime(ctx, key)
 		if err != nil {
 			return false, rlc, err
 		}
@@ -225,9 +226,9 @@ func (g *GCRARateLimiter) RateLimit(key string, quantity int) (bool, RateLimitRe
 		ttl = newTat.Sub(now)
 
 		if tatVal == -1 {
-			updated, err = g.store.SetIfNotExistsWithTTL(key, newTat.UnixNano(), ttl)
+			updated, err = g.store.SetIfNotExistsWithTTL(ctx, key, newTat.UnixNano(), ttl)
 		} else {
-			updated, err = g.store.CompareAndSwapWithTTL(key, tatVal, newTat.UnixNano(), ttl)
+			updated, err = g.store.CompareAndSwapWithTTL(ctx, key, tatVal, newTat.UnixNano(), ttl)
 		}
 
 		if err != nil {

--- a/rate.go
+++ b/rate.go
@@ -12,9 +12,9 @@ const (
 	maxCASAttempts = 10
 )
 
-// A RateLimiter manages limiting the rate of actions by key.
+// A RateLimiterCtx manages limiting the rate of actions by key.
 type RateLimiterCtx interface {
-	// RateLimit checks whether a particular key has exceeded a rate
+	// RateLimitCtx checks whether a particular key has exceeded a rate
 	// limit. It also returns a RateLimitResult to provide additional
 	// information about the state of the RateLimiter.
 	//
@@ -166,11 +166,11 @@ func NewGCRARateLimiterCtx(st GCRAStoreCtx, quota RateQuota) (*GCRARateLimiterCt
 
 // SetMaxCASAttemptsLimit allows you to set the maxCASAttempts limit. This is set to 10
 // be default.
-func (g *GCRARateLimiter) SetMaxCASAttemptsLimit(limit int) {
+func (g *GCRARateLimiterCtx) SetMaxCASAttemptsLimit(limit int) {
 	g.maxCASAttemptsLimit = limit
 }
 
-// RateLimit checks whether a particular key has exceeded a rate
+// RateLimitCtx checks whether a particular key has exceeded a rate
 // limit. It also returns a RateLimitResult to provide additional
 // information about the state of the RateLimiter.
 //

--- a/rate_test.go
+++ b/rate_test.go
@@ -1,6 +1,7 @@
 package throttled_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -12,29 +13,29 @@ import (
 const deniedStatus = 429
 
 type testStore struct {
-	store throttled.GCRAStore
+	store throttled.GCRAStoreCtx
 
 	clock       time.Time
 	failUpdates bool
 }
 
-func (ts *testStore) GetWithTime(key string) (int64, time.Time, error) {
-	v, _, e := ts.store.GetWithTime(key)
+func (ts *testStore) GetWithTime(ctx context.Context, key string) (int64, time.Time, error) {
+	v, _, e := ts.store.GetWithTime(ctx, key)
 	return v, ts.clock, e
 }
 
-func (ts *testStore) SetIfNotExistsWithTTL(key string, value int64, ttl time.Duration) (bool, error) {
+func (ts *testStore) SetIfNotExistsWithTTL(ctx context.Context, key string, value int64, ttl time.Duration) (bool, error) {
 	if ts.failUpdates {
 		return false, nil
 	}
-	return ts.store.SetIfNotExistsWithTTL(key, value, ttl)
+	return ts.store.SetIfNotExistsWithTTL(ctx, key, value, ttl)
 }
 
-func (ts *testStore) CompareAndSwapWithTTL(key string, old, new int64, ttl time.Duration) (bool, error) {
+func (ts *testStore) CompareAndSwapWithTTL(ctx context.Context, key string, old, new int64, ttl time.Duration) (bool, error) {
 	if ts.failUpdates {
 		return false, nil
 	}
-	return ts.store.CompareAndSwapWithTTL(key, old, new, ttl)
+	return ts.store.CompareAndSwapWithTTL(ctx, key, old, new, ttl)
 }
 
 func TestRateLimit(t *testing.T) {
@@ -71,13 +72,13 @@ func TestRateLimit(t *testing.T) {
 		15: {start.Add(15000 * time.Millisecond), 6, 5, 0, -1, true},
 	}
 
-	mst, err := memstore.New(0)
+	mst, err := memstore.NewCtx(0)
 	if err != nil {
 		t.Fatal(err)
 	}
 	st := testStore{store: mst}
 
-	rl, err := throttled.NewGCRARateLimiter(&st, rq)
+	rl, err := throttled.NewGCRARateLimiterCtx(&st, rq)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -86,7 +87,7 @@ func TestRateLimit(t *testing.T) {
 	for i, c := range cases {
 		st.clock = c.now
 
-		limited, context, err := rl.RateLimit("foo", c.volume)
+		limited, context, err := rl.RateLimitCtx(context.Background(), "foo", c.volume)
 		if err != nil {
 			t.Fatalf("%d: %#v", i, err)
 		}
@@ -116,19 +117,19 @@ func TestRateLimit(t *testing.T) {
 func TestRateLimitCustomPeriod(t *testing.T) {
 	period := 10 * time.Millisecond
 	rq := throttled.RateQuota{throttled.PerDuration(3, period), 0}
-	mst, err := memstore.New(27)
+	mst, err := memstore.NewCtx(27)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	st := testStore{store: mst}
-	rl, err := throttled.NewGCRARateLimiter(&st, rq)
+	rl, err := throttled.NewGCRARateLimiterCtx(&st, rq)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	for i := 0; i < 27; i++ {
-		limited, _, err := rl.RateLimit("bar", 1)
+		limited, _, err := rl.RateLimitCtx(context.Background(), "bar", 1)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -145,29 +146,29 @@ func TestRateLimitCustomPeriod(t *testing.T) {
 
 func TestRateLimitUpdateFailures(t *testing.T) {
 	rq := throttled.RateQuota{MaxRate: throttled.PerSec(1), MaxBurst: 1}
-	mst, err := memstore.New(0)
+	mst, err := memstore.NewCtx(0)
 	if err != nil {
 		t.Fatal(err)
 	}
 	st := testStore{store: mst, failUpdates: true}
-	rl, err := throttled.NewGCRARateLimiter(&st, rq)
+	rl, err := throttled.NewGCRARateLimiterCtx(&st, rq)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if _, _, err := rl.RateLimit("foo", 1); err == nil {
+	if _, _, err := rl.RateLimitCtx(context.Background(), "foo", 1); err == nil {
 		t.Error("Expected limiting to fail when store updates fail")
 	}
 }
 
 func TestRateLimitUpdateFailuresWithRetryLimitSetToTwo(t *testing.T) {
 	rq := throttled.RateQuota{MaxRate: throttled.PerSec(1), MaxBurst: 1}
-	mst, err := memstore.New(0)
+	mst, err := memstore.NewCtx(0)
 	if err != nil {
 		t.Fatal(err)
 	}
 	st := testStore{store: mst, failUpdates: true}
-	rl, err := throttled.NewGCRARateLimiter(&st, rq)
+	rl, err := throttled.NewGCRARateLimiterCtx(&st, rq)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -184,19 +185,19 @@ func TestRateLimitUpdateFailuresWithRetryLimitSetToTwo(t *testing.T) {
 func BenchmarkRateLimit(b *testing.B) {
 	limit := 5
 	rq := throttled.RateQuota{MaxRate: throttled.PerSec(1000), MaxBurst: limit - 1}
-	mst, err := memstore.New(0)
+	mst, err := memstore.NewCtx(0)
 	if err != nil {
 		b.Fatal(err)
 	}
 	st := testStore{store: mst}
 
-	rl, err := throttled.NewGCRARateLimiter(&st, rq)
+	rl, err := throttled.NewGCRARateLimiterCtx(&st, rq)
 	if err != nil {
 		b.Fatal(err)
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _, err = rl.RateLimit("foo", 1)
+		_, _, err = rl.RateLimitCtx(context.Background(), "foo", 1)
 	}
 	_ = err
 }

--- a/store.go
+++ b/store.go
@@ -1,12 +1,13 @@
 package throttled
 
 import (
+	"context"
 	"time"
 )
 
-// GCRAStore is the interface to implement to store state for a GCRA
-// rate limiter
-type GCRAStore interface {
+// GCRAStoreCtx is the interface to implement to store state for a GCRA
+// rate limiter that uses a context.Context
+type GCRAStoreCtx interface {
 	// GetWithTime returns the value of the key if it is in the store
 	// or -1 if it does not exist. It also returns the current time at
 	// the Store. The time must be representable as a positive int64
@@ -16,13 +17,13 @@ type GCRAStore interface {
 	// share the same clock. Using separate clocks will work if the
 	// skew is small but not recommended in practice unless you're
 	// lucky enough to be hooked up to GPS or atomic clocks.
-	GetWithTime(key string) (int64, time.Time, error)
+	GetWithTime(ctx context.Context, key string) (int64, time.Time, error)
 
 	// SetIfNotExistsWithTTL sets the value of key only if it is not
 	// already set in the store it returns whether a new value was
 	// set. If the store supports expiring keys and a new value was
 	// set, the key will expire after the provided ttl.
-	SetIfNotExistsWithTTL(key string, value int64, ttl time.Duration) (bool, error)
+	SetIfNotExistsWithTTL(ctx context.Context, key string, value int64, ttl time.Duration) (bool, error)
 
 	// CompareAndSwapWithTTL atomically compares the value at key to
 	// the old value. If it matches, it sets it to the new value and
@@ -30,5 +31,5 @@ type GCRAStore interface {
 	// exist in the store, it returns false with no error. If the
 	// store supports expiring keys and the swap succeeded, the key
 	// will expire after the provided ttl.
-	CompareAndSwapWithTTL(key string, old, new int64, ttl time.Duration) (bool, error)
+	CompareAndSwapWithTTL(ctx context.Context, key string, old, new int64, ttl time.Duration) (bool, error)
 }

--- a/store/deprecated.go
+++ b/store/deprecated.go
@@ -3,7 +3,7 @@ package store // import "github.com/throttled/throttled/v2/store"
 
 import (
 	"github.com/gomodule/redigo/redis"
-
+	"github.com/throttled/throttled/v2"
 	"github.com/throttled/throttled/v2/store/memstore"
 	"github.com/throttled/throttled/v2/store/redigostore"
 )
@@ -11,7 +11,7 @@ import (
 // NewMemStore initializes a new memory-based store.
 //
 // Deprecated: Use github.com/throttled/throttled/v2/store/memstore instead.
-func NewMemStore(maxKeys int) *memstore.MemStore {
+func NewMemStore(maxKeys int) throttled.Store {
 	st, err := memstore.New(maxKeys)
 	if err != nil {
 		// As of this writing, `lru.New` can only return an error if you pass
@@ -24,7 +24,7 @@ func NewMemStore(maxKeys int) *memstore.MemStore {
 // NewRedisStore initializes a new Redigo-based store.
 //
 // Deprecated: Use github.com/throttled/throttled/v2/store/redigostore instead.
-func NewRedisStore(pool *redis.Pool, keyPrefix string, db int) *redigostore.RedigoStore {
+func NewRedisStore(pool *redis.Pool, keyPrefix string, db int) throttled.Store {
 	st, err := redigostore.New(pool, keyPrefix, db)
 	if err != nil {
 		// As of this writing, creating a Redis store never returns an error

--- a/store/goredisstore/goredisstore.go
+++ b/store/goredisstore/goredisstore.go
@@ -2,6 +2,7 @@
 package goredisstore // import "github.com/throttled/throttled/v2/store/goredisstore"
 
 import (
+	"github.com/throttled/throttled/v2"
 	"strings"
 	"time"
 
@@ -40,6 +41,12 @@ func New(client redis.UniversalClient, keyPrefix string) (*GoRedisStore, error) 
 		client: client,
 		prefix: keyPrefix,
 	}, nil
+}
+
+// NewCtx is the version of New that can be used with a context-aware ratelimiter.
+func NewCtx(client redis.UniversalClient, keyPrefix string) (throttled.GCRAStoreCtx, error) {
+	st, err := New(client, keyPrefix)
+	return throttled.WrapStoreWithContext(st), err
 }
 
 // GetWithTime returns the value of the key if it is in the store

--- a/store/goredisstore/goredisstore_test.go
+++ b/store/goredisstore/goredisstore_test.go
@@ -31,7 +31,7 @@ func ExampleNew() {
 	})
 
 	// Setup store
-	store, err := goredisstore.New(client, "throttled:")
+	store, err := goredisstore.NewCtx(client, "throttled:")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -40,7 +40,7 @@ func ExampleNew() {
 	quota := throttled.RateQuota{MaxRate: throttled.PerMin(20), MaxBurst: 5}
 
 	// Then, use store and quota as arguments for NewGCRARateLimiter()
-	throttled.NewGCRARateLimiter(store, quota)
+	throttled.NewGCRARateLimiterCtx(store, quota)
 }
 
 func TestRedisStore(t *testing.T) {
@@ -49,8 +49,8 @@ func TestRedisStore(t *testing.T) {
 	defer clearRedis(c)
 
 	clearRedis(c)
-	storetest.TestGCRAStore(t, st)
-	storetest.TestGCRAStoreTTL(t, st)
+	storetest.TestGCRAStoreCtx(t, st)
+	storetest.TestGCRAStoreTTLCtx(t, st)
 }
 
 func BenchmarkRedisStore(b *testing.B) {
@@ -58,7 +58,7 @@ func BenchmarkRedisStore(b *testing.B) {
 	defer c.Close()
 	defer clearRedis(c)
 
-	storetest.BenchmarkGCRAStore(b, st)
+	storetest.BenchmarkGCRAStoreCtx(b, st)
 }
 
 func clearRedis(c *redis.Client) error {
@@ -70,7 +70,7 @@ func clearRedis(c *redis.Client) error {
 	return c.Del(keys...).Err()
 }
 
-func setupRedis(tb testing.TB, ttl time.Duration) (*redis.Client, *goredisstore.GoRedisStore) {
+func setupRedis(tb testing.TB, ttl time.Duration) (*redis.Client, throttled.GCRAStoreCtx) {
 	client := redis.NewClient(&redis.Options{
 		PoolSize:    10, // default
 		IdleTimeout: 30 * time.Second,
@@ -84,7 +84,7 @@ func setupRedis(tb testing.TB, ttl time.Duration) (*redis.Client, *goredisstore.
 		tb.Skip("redis server not available on localhost port 6379")
 	}
 
-	st, err := goredisstore.New(client, redisTestPrefix)
+	st, err := goredisstore.NewCtx(client, redisTestPrefix)
 	if err != nil {
 		client.Close()
 		tb.Fatal(err)

--- a/store/memstore/memstore.go
+++ b/store/memstore/memstore.go
@@ -2,6 +2,7 @@
 package memstore // import "github.com/throttled/throttled/v2/store/memstore"
 
 import (
+	"github.com/throttled/throttled/v2"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -45,6 +46,12 @@ func New(maxKeys int) (*MemStore, error) {
 		}
 	}
 	return m, nil
+}
+
+// NewCtx is the version of New that can be used with a context-aware ratelimiter.
+func NewCtx(maxKeys int) (throttled.GCRAStoreCtx, error) {
+	st, err := New(maxKeys)
+	return throttled.WrapStoreWithContext(st), err
 }
 
 // SetTimeNow makes this store use the given function instead of time.Now().

--- a/store/memstore/memstore_test.go
+++ b/store/memstore/memstore_test.go
@@ -8,33 +8,33 @@ import (
 )
 
 func TestMemStoreLRU(t *testing.T) {
-	st, err := memstore.New(10)
+	st, err := memstore.NewCtx(10)
 	if err != nil {
 		t.Fatal(err)
 	}
-	storetest.TestGCRAStore(t, st)
+	storetest.TestGCRAStoreCtx(t, st)
 }
 
 func TestMemStoreUnlimited(t *testing.T) {
-	st, err := memstore.New(10)
+	st, err := memstore.NewCtx(10)
 	if err != nil {
 		t.Fatal(err)
 	}
-	storetest.TestGCRAStore(t, st)
+	storetest.TestGCRAStoreCtx(t, st)
 }
 
 func BenchmarkMemStoreLRU(b *testing.B) {
-	st, err := memstore.New(10)
+	st, err := memstore.NewCtx(10)
 	if err != nil {
 		b.Fatal(err)
 	}
-	storetest.BenchmarkGCRAStore(b, st)
+	storetest.BenchmarkGCRAStoreCtx(b, st)
 }
 
 func BenchmarkMemStoreUnlimited(b *testing.B) {
-	st, err := memstore.New(0)
+	st, err := memstore.NewCtx(0)
 	if err != nil {
 		b.Fatal(err)
 	}
-	storetest.BenchmarkGCRAStore(b, st)
+	storetest.BenchmarkGCRAStoreCtx(b, st)
 }

--- a/store/redigostore/redigostore.go
+++ b/store/redigostore/redigostore.go
@@ -2,6 +2,7 @@
 package redigostore // import "github.com/throttled/throttled/v2/store/redigostore"
 
 import (
+	"github.com/throttled/throttled/v2"
 	"strings"
 	"time"
 
@@ -50,6 +51,12 @@ func New(pool RedigoPool, keyPrefix string, db int) (*RedigoStore, error) {
 		prefix: keyPrefix,
 		db:     db,
 	}, nil
+}
+
+// NewCtx is the version of New that can be used with a context-aware ratelimiter.
+func NewCtx(pool *redis.Pool, keyPrefix string, db int) (throttled.GCRAStoreCtx, error) {
+	st, err := New(pool, keyPrefix, db)
+	return throttled.WrapStoreWithContext(st), err
 }
 
 // GetWithTime returns the value of the key if it is in the store

--- a/store/redigostore/redigostore_test.go
+++ b/store/redigostore/redigostore_test.go
@@ -1,6 +1,7 @@
 package redigostore_test
 
 import (
+	"github.com/throttled/throttled/v2"
 	"testing"
 	"time"
 
@@ -36,8 +37,8 @@ func TestRedisStore(t *testing.T) {
 	defer clearRedis(c)
 
 	clearRedis(c)
-	storetest.TestGCRAStore(t, st)
-	storetest.TestGCRAStoreTTL(t, st)
+	storetest.TestGCRAStoreCtx(t, st)
+	storetest.TestGCRAStoreTTLCtx(t, st)
 }
 
 func BenchmarkRedisStore(b *testing.B) {
@@ -45,7 +46,7 @@ func BenchmarkRedisStore(b *testing.B) {
 	defer c.Close()
 	defer clearRedis(c)
 
-	storetest.BenchmarkGCRAStore(b, st)
+	storetest.BenchmarkGCRAStoreCtx(b, st)
 }
 
 func clearRedis(c redis.Conn) error {
@@ -61,7 +62,7 @@ func clearRedis(c redis.Conn) error {
 	return nil
 }
 
-func setupRedis(tb testing.TB, ttl time.Duration) (redis.Conn, *redigostore.RedigoStore) {
+func setupRedis(tb testing.TB, ttl time.Duration) (redis.Conn, throttled.GCRAStoreCtx) {
 	pool := getPool()
 	c := pool.Get()
 
@@ -75,7 +76,7 @@ func setupRedis(tb testing.TB, ttl time.Duration) (redis.Conn, *redigostore.Redi
 		tb.Fatal(err)
 	}
 
-	st, err := redigostore.New(pool, redisTestPrefix, redisTestDB)
+	st, err := redigostore.NewCtx(pool, redisTestPrefix, redisTestDB)
 	if err != nil {
 		c.Close()
 		tb.Fatal(err)

--- a/store/storetest/deprecated.go
+++ b/store/storetest/deprecated.go
@@ -1,0 +1,27 @@
+package storetest
+
+import (
+	"github.com/throttled/throttled/v2"
+	"testing"
+)
+
+// TestGCRAStore provides an adapter for TestGCRAStoreCtx
+//
+// Deprecated: implement GCRAStoreCtx and use TestGCRAStoreCtx instead.
+func TestGCRAStore(t *testing.T, st throttled.GCRAStore) {
+	TestGCRAStoreCtx(t, throttled.WrapStoreWithContext(st))
+}
+
+// TestGCRAStoreTTL provides an adapter for TestGCRAStoreTTLCtx
+//
+// Deprecated: implement GCRAStoreCtx and use TestGCRAStoreTTLCtx instead.
+func TestGCRAStoreTTL(t *testing.T, st throttled.GCRAStore) {
+	TestGCRAStoreTTLCtx(t, throttled.WrapStoreWithContext(st))
+}
+
+// BenchmarkGCRAStore provides an adapter for BenchmarkGCRAStoreCtx
+//
+// Deprecated: implement GCRAStoreCtx and use BenchmarkGCRAStoreCtx instead.
+func BenchmarkGCRAStore(b *testing.B, st throttled.GCRAStore) {
+	BenchmarkGCRAStoreCtx(b, throttled.WrapStoreWithContext(st))
+}

--- a/store/storetest/storetest.go
+++ b/store/storetest/storetest.go
@@ -2,6 +2,7 @@
 package storetest // import "github.com/throttled/throttled/v2/store/storetest"
 
 import (
+	"context"
 	"math/rand"
 	"strconv"
 	"sync/atomic"
@@ -14,9 +15,11 @@ import (
 // TestGCRAStore tests the behavior of a GCRAStore implementation for
 // compliance with the throttled API. It does not require support
 // for TTLs.
-func TestGCRAStore(t *testing.T, st throttled.GCRAStore) {
+func TestGCRAStoreCtx(t *testing.T, st throttled.GCRAStoreCtx) {
+	ctx := context.Background()
+
 	// GetWithTime a missing key
-	if have, _, err := st.GetWithTime("foo"); err != nil {
+	if have, _, err := st.GetWithTime(ctx, "foo"); err != nil {
 		t.Fatal(err)
 	} else if have != -1 {
 		t.Errorf("expected GetWithTime to return -1 for a missing key but got %d", have)
@@ -25,7 +28,7 @@ func TestGCRAStore(t *testing.T, st throttled.GCRAStore) {
 	// SetIfNotExists on a new key
 	want := int64(1)
 
-	if set, err := st.SetIfNotExistsWithTTL("foo", want, 0); err != nil {
+	if set, err := st.SetIfNotExistsWithTTL(ctx, "foo", want, 0); err != nil {
 		t.Fatal(err)
 	} else if !set {
 		t.Errorf("expected SetIfNotExists on an empty key to succeed")
@@ -33,7 +36,7 @@ func TestGCRAStore(t *testing.T, st throttled.GCRAStore) {
 
 	before := time.Now()
 
-	if have, now, err := st.GetWithTime("foo"); err != nil {
+	if have, now, err := st.GetWithTime(ctx, "foo"); err != nil {
 		t.Fatal(err)
 	} else if have != want {
 		t.Errorf("expected GetWithTime to return %d but got %d", want, have)
@@ -50,27 +53,27 @@ func TestGCRAStore(t *testing.T, st throttled.GCRAStore) {
 	}
 
 	// SetIfNotExists on an existing key
-	if set, err := st.SetIfNotExistsWithTTL("foo", 123, 0); err != nil {
+	if set, err := st.SetIfNotExistsWithTTL(ctx, "foo", 123, 0); err != nil {
 		t.Fatal(err)
 	} else if set {
 		t.Errorf("expected SetIfNotExists on an existing key to fail")
 	}
 
-	if have, _, err := st.GetWithTime("foo"); err != nil {
+	if have, _, err := st.GetWithTime(ctx, "foo"); err != nil {
 		t.Fatal(err)
 	} else if have != want {
 		t.Errorf("expected GetWithTime to return %d but got %d", want, have)
 	}
 
 	// SetIfNotExists on a different key
-	if set, err := st.SetIfNotExistsWithTTL("bar", 456, 0); err != nil {
+	if set, err := st.SetIfNotExistsWithTTL(ctx, "bar", 456, 0); err != nil {
 		t.Fatal(err)
 	} else if !set {
 		t.Errorf("expected SetIfNotExists on an empty key to succeed")
 	}
 
 	// Returns the false on a missing key
-	if swapped, err := st.CompareAndSwapWithTTL("baz", 1, 2, 0); err != nil {
+	if swapped, err := st.CompareAndSwapWithTTL(ctx, "baz", 1, 2, 0); err != nil {
 		t.Fatal(err)
 	} else if swapped {
 		t.Errorf("expected CompareAndSwap to fail on a missing key")
@@ -79,26 +82,26 @@ func TestGCRAStore(t *testing.T, st throttled.GCRAStore) {
 	// Test a successful CAS
 	want = int64(2)
 
-	if swapped, err := st.CompareAndSwapWithTTL("foo", 1, want, 0); err != nil {
+	if swapped, err := st.CompareAndSwapWithTTL(ctx, "foo", 1, want, 0); err != nil {
 		t.Fatal(err)
 	} else if !swapped {
 		t.Errorf("expected CompareAndSwap to succeed")
 	}
 
-	if have, _, err := st.GetWithTime("foo"); err != nil {
+	if have, _, err := st.GetWithTime(ctx, "foo"); err != nil {
 		t.Fatal(err)
 	} else if have != want {
 		t.Errorf("expected GetWithTime to return %d but got %d", want, have)
 	}
 
 	// Test an unsuccessful CAS
-	if swapped, err := st.CompareAndSwapWithTTL("foo", 1, 2, 0); err != nil {
+	if swapped, err := st.CompareAndSwapWithTTL(ctx, "foo", 1, 2, 0); err != nil {
 		t.Fatal(err)
 	} else if swapped {
 		t.Errorf("expected CompareAndSwap to fail")
 	}
 
-	if have, _, err := st.GetWithTime("foo"); err != nil {
+	if have, _, err := st.GetWithTime(ctx, "foo"); err != nil {
 		t.Fatal(err)
 	} else if have != want {
 		t.Errorf("expected GetWithTime to return %d but got %d", want, have)
@@ -106,16 +109,17 @@ func TestGCRAStore(t *testing.T, st throttled.GCRAStore) {
 }
 
 // TestGCRAStoreTTL tests the behavior of TTLs in a GCRAStore implementation.
-func TestGCRAStoreTTL(t *testing.T, st throttled.GCRAStore) {
+func TestGCRAStoreTTLCtx(t *testing.T, st throttled.GCRAStoreCtx) {
 	ttl := time.Second
 	want := int64(1)
 	key := "ttl"
+	ctx := context.Background()
 
-	if _, err := st.SetIfNotExistsWithTTL(key, want, ttl); err != nil {
+	if _, err := st.SetIfNotExistsWithTTL(ctx, key, want, ttl); err != nil {
 		t.Fatal(err)
 	}
 
-	if have, _, err := st.GetWithTime(key); err != nil {
+	if have, _, err := st.GetWithTime(ctx, key); err != nil {
 		t.Fatal(err)
 	} else if have != want {
 		t.Errorf("expected GetWithTime to return %d, got %d", want, have)
@@ -124,7 +128,7 @@ func TestGCRAStoreTTL(t *testing.T, st throttled.GCRAStore) {
 	// I can't think of a generic way to test expiration without a sleep
 	time.Sleep(ttl + time.Millisecond)
 
-	if have, _, err := st.GetWithTime(key); err != nil {
+	if have, _, err := st.GetWithTime(ctx, key); err != nil {
 		t.Fatal(err)
 	} else if have != -1 {
 		t.Errorf("expected GetWithTime to fail on an expired key but got %d", have)
@@ -134,7 +138,7 @@ func TestGCRAStoreTTL(t *testing.T, st throttled.GCRAStore) {
 // BenchmarkGCRAStore runs parallel benchmarks against a GCRAStore implementation.
 // Aside from being useful for performance testing, this is useful for finding
 // race conditions with the Go race detector.
-func BenchmarkGCRAStore(b *testing.B, st throttled.GCRAStore) {
+func BenchmarkGCRAStoreCtx(b *testing.B, st throttled.GCRAStoreCtx) {
 	seed := int64(42)
 	var attempts, updates int64
 
@@ -145,21 +149,22 @@ func BenchmarkGCRAStore(b *testing.B, st throttled.GCRAStore) {
 		gen := rand.New(rand.NewSource(seedValue))
 
 		for pb.Next() {
+			ctx := context.Background()
 			key := strconv.FormatInt(gen.Int63n(50), 10)
 
 			var v int64
 			var updated bool
 
-			v, _, err := st.GetWithTime(key)
+			v, _, err := st.GetWithTime(ctx, key)
 			if v == -1 {
-				updated, err = st.SetIfNotExistsWithTTL(key, gen.Int63(), 0)
+				updated, err = st.SetIfNotExistsWithTTL(ctx, key, gen.Int63(), 0)
 				if err != nil {
 					b.Error(err)
 				}
 			} else if err != nil {
 				b.Error(err)
 			} else {
-				updated, err = st.CompareAndSwapWithTTL(key, v, gen.Int63(), 0)
+				updated, err = st.CompareAndSwapWithTTL(ctx, key, v, gen.Int63(), 0)
 				if err != nil {
 					b.Error(err)
 				}

--- a/store/storetest/storetest.go
+++ b/store/storetest/storetest.go
@@ -12,7 +12,7 @@ import (
 	"github.com/throttled/throttled/v2"
 )
 
-// TestGCRAStore tests the behavior of a GCRAStore implementation for
+// TestGCRAStoreCtx tests the behavior of a GCRAStore implementation for
 // compliance with the throttled API. It does not require support
 // for TTLs.
 func TestGCRAStoreCtx(t *testing.T, st throttled.GCRAStoreCtx) {
@@ -108,7 +108,7 @@ func TestGCRAStoreCtx(t *testing.T, st throttled.GCRAStoreCtx) {
 	}
 }
 
-// TestGCRAStoreTTL tests the behavior of TTLs in a GCRAStore implementation.
+// TestGCRAStoreTTLCtx tests the behavior of TTLs in a GCRAStore implementation.
 func TestGCRAStoreTTLCtx(t *testing.T, st throttled.GCRAStoreCtx) {
 	ttl := time.Second
 	want := int64(1)
@@ -135,7 +135,7 @@ func TestGCRAStoreTTLCtx(t *testing.T, st throttled.GCRAStoreCtx) {
 	}
 }
 
-// BenchmarkGCRAStore runs parallel benchmarks against a GCRAStore implementation.
+// BenchmarkGCRAStoreCtx runs parallel benchmarks against a GCRAStore implementation.
 // Aside from being useful for performance testing, this is useful for finding
 // race conditions with the Go race detector.
 func BenchmarkGCRAStoreCtx(b *testing.B, st throttled.GCRAStoreCtx) {


### PR DESCRIPTION
This allows the usage of stores that use a context, for example to cancel a request or to perform tracing. Saw this being discussed in https://github.com/throttled/throttled/pull/67 and https://github.com/throttled/throttled/issues/57.

All functions and interfaces that have changed signatures, have Ctx as a suffix to maintain full backwards compatibility and provide a smooth migration path. Or at least... I think so.

Not all context's are actually used yet. All the old stores just use an adapter around the old store that silently drops the provided context. But having it in the signature, allow the stores to be changed gradually. And I also have a PR incoming for using it with `redis-go.v8`.

Documentation can maybe use some work. So any suggestions regarding this or any feedback on the used approach are very welcome!