### PR TITLE
Add Go 1.15 and 1.16 to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
           - 1.12.x
           - 1.13.x
           - 1.14.x
+          - 1.15.x
+          - 1.16.x
 
     steps:
       - name: Install Go


### PR DESCRIPTION
Add a couple more modern versions of Go to build in CI.