### PR TITLE
Add new Go versions, drop older version support, drop Golint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,15 +15,17 @@ jobs:
     strategy:
       matrix:
         go:
-          - 1.12.x
-          - 1.13.x
-          - 1.14.x
-          - 1.15.x
-          - 1.16.x
+          - 1.13
+          - 1.14
+          - 1.15
+          - 1.16
+          - 1.17
+          - 1.18
+          - 1.19
 
     steps:
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go }}
 
@@ -37,9 +39,6 @@ jobs:
           echo "pwd=$(pwd)"
           echo "HOME=${HOME}"
           echo "GITHUB_WORKSPACE=${GITHUB_WORKSPACE}"
-
-      - name: Install Golint
-        run: go get -u golang.org/x/lint/golint
 
       - name: "Go: Build"
         run: go build ./...
@@ -60,6 +59,3 @@ jobs:
 
       - name: "Check: Gofmt"
         run: scripts/check_gofmt.sh
-
-      - name: "Check: Lint"
-        run: "$(go env GOPATH)/bin/golint -set_exit_status ./..."


### PR DESCRIPTION
Add versions up to 1.19, and drop 1.12 which is very old, and seems to
be failing now.

Drop Golint, which as per its repo [1], is deprecated and frozen.

[1] https://github.com/golang/lint