### PR TITLE
Add new Go version + a few tweaks to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,14 @@ jobs:
     strategy:
       matrix:
         go:
-          - 1.13
-          - 1.14
-          - 1.15
-          - 1.16
-          - 1.17
-          - 1.18
-          - 1.19
+          - "1.13"
+          - "1.14"
+          - "1.15"
+          - "1.16"
+          - "1.17"
+          - "1.18"
+          - "1.19"
+          - "1.20"
 
     steps:
       - name: Install Go
@@ -30,7 +31,7 @@ jobs:
           go-version: ${{ matrix.go }}
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Debug
         run: |
@@ -53,9 +54,6 @@ jobs:
         run: |
           go test -coverprofile=throttled.coverage.out .
           go test -coverprofile=store.coverage.out ./store
-
-      - name: "Go: Vet"
-        run: go vet ./...
 
       - name: "Check: Gofmt"
         run: scripts/check_gofmt.sh


### PR DESCRIPTION
A few tweaks for CI:

* Add Go 1.20.
* Move to checkout v3 action.
* Remove use of `go vet` which has been built into `go test` for some
  time.
* Wrap Go versions in quotes so 1.20 isn't interpreted as "1.2".