### PR TITLE
Use the RedigoPool interface in redigostore.NewCtx

### DIFF
--- a/store/redigostore/redigostore.go
+++ b/store/redigostore/redigostore.go
@@ -54,7 +54,7 @@ func New(pool RedigoPool, keyPrefix string, db int) (*RedigoStore, error) {
 }
 
 // NewCtx is the version of New that can be used with a context-aware ratelimiter.
-func NewCtx(pool *redis.Pool, keyPrefix string, db int) (throttled.GCRAStoreCtx, error) {
+func NewCtx(pool RedigoPool, keyPrefix string, db int) (throttled.GCRAStoreCtx, error) {
 	st, err := New(pool, keyPrefix, db)
 	return throttled.WrapStoreWithContext(st), err
 }


### PR DESCRIPTION
Currently, the `redigostore.New` function takes a `RedigoPool` interface, allowing consumers to use pools from https://github.com/mna/redisc, for example.

This might be a simple overlook, but the `redigostore.NewCtx` does not accept that interface, requiring the concrete `*redis.Pool` type.

There's a simple workaround: using the `New` function (without context), then wrapping it with `throttled.WrapStoreWithContext`, but it would be nicer to make `NewCtx` accept the interface directly.